### PR TITLE
Tx Page polling

### DIFF
--- a/app/components/TxHistory/TxHistory.js
+++ b/app/components/TxHistory/TxHistory.js
@@ -19,7 +19,11 @@ type Props = {
 @observer
 class TxHistory extends Component<Props> {
   componentDidMount() {
-    this.props.txhistory.fetch()
+    this.props.txhistory.initPolling()
+  }
+
+  componentWillUnmount() {
+    this.props.txhistory.reset()
   }
 
   renderTransactionsCell(tx: ObservableTransactionResponse) {

--- a/app/components/TxHistory/__tests__/TxHistory.spec.js
+++ b/app/components/TxHistory/__tests__/TxHistory.spec.js
@@ -28,6 +28,7 @@ describe('TxHistory', () => {
     it('renders Loading transactions text ', () => {
       const { txhistory } = states
       txhistory.isFetching = true
+      component.update()
       expect(component.find('.loading-transactions').text()).toBe('Loading transactions ...')
     })
   })

--- a/app/states/__tests__/tx-history-state.spec.js
+++ b/app/states/__tests__/tx-history-state.spec.js
@@ -4,6 +4,10 @@ import { getTxHistory } from '../../services/api-service'
 jest.mock('../../services/api-service', () => ({
   getTxHistory: jest.fn(),
 }))
+
+jest.spyOn(window, 'setInterval')
+jest.spyOn(window, 'clearInterval')
+
 const mockTransactions = [
   {
     txHash: '0a4f2e0d91edfd3d8450b0169cf694ae36a35b4c2789cefa6a098ecd96362376',
@@ -15,9 +19,19 @@ const mockTransactions = [
     deltas: [{ asset: '00', amount: 5000003406 }],
     blockNumber: 0,
   }]
+
+afterEach(() => {
+  getTxHistory.mockReset()
+  window.setInterval.mockReset()
+  window.clearInterval.mockReset()
+})
+
+let txHistoryState
+beforeEach(() => {
+  txHistoryState = new TxHistoryState()
+})
 describe('TxHistoryState', () => {
   describe('after construction', () => {
-    const txHistoryState = new TxHistoryState()
     it('sets the tx object to the correct zero values', () => {
       expect(txHistoryState.skip).toBe(0)
       expect(txHistoryState.transactions).toEqual([])
@@ -26,54 +40,109 @@ describe('TxHistoryState', () => {
     })
   })
 
-  describe('when fetch is called', () => {
-    describe('before getTxHistory has resolved', () => {
-      getTxHistory.mockReturnValue(new Promise(() => {}))
-      const txHistoryState = new TxHistoryState()
-      txHistoryState.fetch()
-      it('calls getTxHistory with skip: 0 and take: 20', () => {
-        expect(getTxHistory).toHaveBeenCalledWith({ skip: 0, take: 20 })
-      })
-      it('sets isFetching to true', () => {
-        expect(txHistoryState.isFetching).toBe(true)
-      })
+  describe('when initPolling is called', () => {
+    beforeEach(() => {
+      txHistoryState.initPolling()
+    })
+    it('calls setInterval with the fetch function', () => {
+      expect(window.setInterval).toHaveBeenCalledWith(expect.any(Function), 5000)
+    })
+  })
+
+  describe('when reset is called', () => {
+    beforeEach(() => {
+      txHistoryState.currentPageSize = 90
+      txHistoryState.skip = 9
+      txHistoryState.isFetching = true
+      txHistoryState.transactions = [...mockTransactions]
+
+      txHistoryState.reset()
     })
 
-    describe('after getTxHistory has resolved with a non empty list', () => {
-      getTxHistory.mockReturnValue(Promise.resolve(mockTransactions))
-      const txHistoryState = new TxHistoryState()
-      txHistoryState.transactions = [...mockTransactions, ...mockTransactions]
-      txHistoryState.fetch()
-      it('sets isFetching to false', () => {
-        expect(txHistoryState.isFetching).toBe(false)
-      })
-
-      it('increments the currentPageSize by the size of the transactions', () => {
-        expect(txHistoryState.currentPageSize).toBe(2)
-      })
-
-      it('sets the transtions to the resolved transactions', () => {
-        expect(txHistoryState.transactions).toEqual(mockTransactions)
-      })
+    it('sets the tx object to the correct zero values', () => {
+      expect(txHistoryState.skip).toBe(0)
+      expect(txHistoryState.transactions).toEqual([])
+      expect(txHistoryState.currentPageSize).toBe(0)
+      expect(txHistoryState.isFetching).toBe(false)
     })
 
-    describe('after getTxHistory has resolved with an empty list', () => {
-      getTxHistory.mockReturnValue(Promise.resolve([]))
-      const txHistoryState = new TxHistoryState()
-      const testExistingTransactions = [...mockTransactions, ...mockTransactions]
-      txHistoryState.transactions = testExistingTransactions
-      txHistoryState.currentPageSize = 60
-      txHistoryState.fetch()
-      it('sets isFetching to false', () => {
-        expect(txHistoryState.isFetching).toBe(false)
+    it('calls clearInterval', () => {
+      expect(window.clearInterval).toHaveBeenCalled()
+    })
+  })
+
+  describe('when fetch is already in progress', () => {
+    beforeEach(() => {
+      txHistoryState.isFetching = true
+    })
+
+    describe('and fetch is called', () => {
+      beforeEach(() => {
+        txHistoryState.fetch()
+      })
+      it('does not call getTxHistory', () => {
+        expect(getTxHistory).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('when fetch is not in progress', () => {
+    describe('and fetch is called', () => {
+      describe('before getTxHistory has resolved', () => {
+        beforeEach(() => {
+          getTxHistory.mockReturnValue(new Promise(() => {}))
+          txHistoryState.fetch()
+        })
+
+        it('calls getTxHistory with skip: 0 and take: 20', () => {
+          expect(getTxHistory).toHaveBeenCalledWith({ skip: 0, take: 20 })
+        })
+        it('sets isFetching to true', () => {
+          expect(txHistoryState.isFetching).toBe(true)
+        })
       })
 
-      it('does not affect currentPageSize', () => {
-        expect(txHistoryState.currentPageSize).toBe(60)
+      describe('after getTxHistory has resolved with a non empty list', () => {
+        beforeEach(() => {
+          getTxHistory.mockReturnValue(Promise.resolve(mockTransactions))
+          txHistoryState.transactions = [...mockTransactions, ...mockTransactions]
+          txHistoryState.fetch()
+        })
+
+        it('sets isFetching to false', () => {
+          expect(txHistoryState.isFetching).toBe(false)
+        })
+
+        it('increments the currentPageSize by the size of the transactions', () => {
+          expect(txHistoryState.currentPageSize).toBe(2)
+        })
+
+        it('sets the transtions to the resolved transactions', () => {
+          expect(txHistoryState.transactions).toEqual(mockTransactions)
+        })
       })
 
-      it('does not affect existing transactions', () => {
-        expect(txHistoryState.transactions).toEqual(testExistingTransactions)
+      describe('after getTxHistory has resolved with an empty list', () => {
+        const testExistingTransactions = [...mockTransactions, ...mockTransactions]
+
+        beforeEach(() => {
+          getTxHistory.mockReturnValue(Promise.resolve([]))
+          txHistoryState.transactions = testExistingTransactions
+          txHistoryState.currentPageSize = 60
+          txHistoryState.fetch()
+        })
+
+        it('sets isFetching to false', () => {
+          expect(txHistoryState.isFetching).toBe(false)
+        })
+
+        it('does not affect currentPageSize', () => {
+          expect(txHistoryState.currentPageSize).toBe(60)
+        })
+
+        it('does not affect existing transactions', () => {
+          expect(txHistoryState.transactions).toEqual(testExistingTransactions)
+        })
       })
     })
   })


### PR DESCRIPTION
Adds polling on transactions page to fetch transactions every 5 seconds.
Transactions are cleared and disposed when user navigates away from the
page.