### PR TITLE
(SQUASH NEEDED) Protect write ops when syncing

### DIFF
--- a/app/components/ActivateContract/ActivateContract.js
+++ b/app/components/ActivateContract/ActivateContract.js
@@ -7,6 +7,7 @@ import { head } from 'lodash'
 import Highlight from 'react-highlight'
 import cx from 'classnames'
 
+import enforceSynced from '../../services/enforceSynced'
 import confirmPasswordModal from '../../services/confirmPasswordModal'
 import { normalizeTokens, zenToKalapa, stringToNumber } from '../../utils/helpers'
 import { CANCEL_ICON_SRC } from '../../constants/imgSources'
@@ -324,7 +325,7 @@ class ActivateContract extends Component<Props> {
               <button
                 className={cx('button-on-right', { loading: inprogress })}
                 disabled={this.isSubmitButtonDisabled()}
-                onClick={this.onActivateContractClicked}
+                onClick={enforceSynced(this.onActivateContractClicked)}
               >{inprogress ? 'Activating' : 'Activate'}
               </button>
             </Flexbox>

--- a/app/components/RunContract/RunContract.js
+++ b/app/components/RunContract/RunContract.js
@@ -6,6 +6,7 @@ import { toInteger } from 'lodash'
 import PropTypes from 'prop-types'
 
 import confirmPasswordModal from '../../services/confirmPasswordModal'
+import enforceSynced from '../../services/enforceSynced'
 import db from '../../services/store'
 import { stringToNumber, isZenAsset } from '../../utils/helpers'
 import Layout from '../UI/Layout/Layout'
@@ -224,7 +225,7 @@ class RunContract extends Component {
             <Flexbox flexGrow={1} justifyContent="flex-end" flexDirection="row">
               <button
                 disabled={this.isSubmitButtonDisabled()}
-                onClick={this.onRunContractClicked}
+                onClick={enforceSynced(this.onRunContractClicked)}
               >
                 {inprogress ? 'Running' : 'Run'}
               </button>

--- a/app/components/SendTx/SendTx.js
+++ b/app/components/SendTx/SendTx.js
@@ -6,6 +6,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 
+import enforceSynced from '../../services/enforceSynced'
 import confirmPasswordModal from '../../services/confirmPasswordModal'
 import IsValidIcon from '../Icons/IsValidIcon'
 import { isValidAddress, isZenAsset, stringToNumber } from '../../utils/helpers'
@@ -226,7 +227,7 @@ class SendTx extends Component {
               <button
                 className={cx('button-on-right', { loading: this.props.transaction.inprogress })}
                 disabled={this.isSubmitButtonDisabled()}
-                onClick={this.onSubmitButtonClicked}
+                onClick={enforceSynced(this.onSubmitButtonClicked)}
               >
                 {this.props.transaction.inprogress ? 'Sending' : 'Send'}
               </button>

--- a/app/components/UI/Sidebar/Sidebar.js
+++ b/app/components/UI/Sidebar/Sidebar.js
@@ -50,7 +50,7 @@ class Sidebar extends Component<Props> {
       )
     }
 
-    if (!isSynced) {
+    if (isSynced) {
       return (
         <div>
           <span className="data-name" title="Syncing">

--- a/app/components/UI/Sidebar/Sidebar.js
+++ b/app/components/UI/Sidebar/Sidebar.js
@@ -3,7 +3,6 @@ import moment from 'moment'
 import { inject, observer } from 'mobx-react'
 import { Link, NavLink } from 'react-router-dom'
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
-import cx from 'classnames'
 
 import pjson from '../../../../package.json'
 import { LOGO_SRC } from '../../../constants/imgSources'
@@ -33,14 +32,14 @@ class Sidebar extends Component<Props> {
 
   renderSyncingStatus() {
     const {
-      initialBlockDownload, connections, blocks, headers,
+      isSynced, connections, isSyncing,
     } = this.props.networkState
 
     if (connections === 0) {
       return
     }
 
-    if (initialBlockDownload || (blocks < headers)) {
+    if (isSyncing) {
       return (
         <div>
           <span className="data-name" title="Syncing">
@@ -51,7 +50,7 @@ class Sidebar extends Component<Props> {
       )
     }
 
-    if (!initialBlockDownload) {
+    if (!isSynced) {
       return (
         <div>
           <span className="data-name" title="Syncing">

--- a/app/components/UI/Sidebar/_Sidebar.scss
+++ b/app/components/UI/Sidebar/_Sidebar.scss
@@ -1,5 +1,22 @@
 ul { list-style: none; }
 
+.network-status {
+  padding: 5px 0px 0px 20px;
+  border-top: 1px solid $almost-black;
+  font-size: 12px;
+  font-weight: 300;
+  line-height: 1.42;
+  color: $bright-grey;
+
+  .data-name { font-weight: 400; }
+
+  .network-data-point.bottom {
+    display: block;
+    position: absolute;
+    bottom: 15px;
+  }
+}
+
 nav.sidebar {
   position: fixed;
   left: 0;
@@ -19,23 +36,6 @@ nav.sidebar {
   .menu {
     height: calc(100% - 285px);
     position: relative;
-  }
-
-  .network-status {
-    padding: 5px 0px 0px 20px;
-    border-top: 1px solid $almost-black;
-    font-size: 12px;
-    font-weight: 300;
-    line-height: 1.42;
-    color: $bright-grey;
-
-    .data-name { font-weight: 400; }
-
-    .network-data-point.bottom {
-      display: block;
-      position: absolute;
-      bottom: 15px;
-    }
   }
 
   ul {

--- a/app/services/enforceSynced.js
+++ b/app/services/enforceSynced.js
@@ -1,0 +1,151 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import swal from 'sweetalert'
+import FontAwesomeIcon from '@fortawesome/react-fontawesome'
+import { observer } from 'mobx-react'
+
+import { networkState } from '../states'
+import NetworkState from '../states/network-state'
+
+export default function enforceSynced(fnToProtect) {
+  return async function enforceSyncedInner(...args) {
+    if (!networkState.isSynced) {
+      const canContinue = await swal({
+        text: 'Must be fully synced to perform this operation!',
+        icon: 'info',
+        content: getModalContent(),
+        buttons: false,
+      })
+      if (!canContinue) {
+        return
+      }
+    }
+    fnToProtect(...args)
+  }
+}
+
+type Props = {
+  networkState: NetworkState
+};
+
+@observer
+class ProtectWhenSyncincModal extends React.Component<Props> {
+  renderSyncingStatus() {
+    const {
+      isSynced, connections, isSyncing,
+    } = this.props.networkState
+
+    if (connections === 0) {
+      return
+    }
+
+    if (isSyncing) {
+      return (
+        <div>
+          <span className="data-name" title="Syncing">
+            <FontAwesomeIcon icon={['far', 'spinner-third']} spin />
+          </span>
+          <span className="data-point"> Syncing</span>
+        </div>
+      )
+    }
+
+    if (isSynced) {
+      return (
+        <div>
+          <span className="data-name" title="Syncing">
+            <FontAwesomeIcon icon={['fas', 'circle']} className="green" />
+          </span>
+          <span className="data-point"> Synced</span>
+        </div>
+      )
+    }
+  }
+
+  renderPartialNetworkStatus() {
+    const {
+      chain, blocks, headers, connections, connectedToNode,
+    } = this.props.networkState
+
+    if (!connectedToNode) {
+      return (
+        <div className="network-status">
+          <span className="data-name">
+            <FontAwesomeIcon icon={['fas', 'circle']} className="red" />
+          </span>
+          <span className="data-point"> Not Connected to a Node</span>
+        </div>
+      )
+    }
+    if (connections === 0) {
+      return (
+        <div className="network-status">
+          <span className="data-name">
+            <FontAwesomeIcon icon={['far', 'spinner-third']} spin />
+          </span>
+          <span className="data-point"> Connecting</span>
+        </div>
+      )
+    }
+    return (
+      <div className="network-status">
+        <div>
+          <span className="data-name">Chain: </span>
+          <span className="data-point">{chain}</span>
+        </div>
+        <div>
+          <span className="data-name">Blocks: </span>
+          <span className="data-point">{blocks.toLocaleString()}</span>
+        </div>
+        <div>
+          <span className="data-name">Headers: </span>
+          <span className="data-point">{headers.toLocaleString()}</span>
+        </div>
+        <div>
+          <span className="data-name" title="Connections">Connections: </span>
+          <span className="data-point">{connections}</span>
+        </div>
+        <div>
+          { this.renderSyncingStatus() }
+        </div>
+      </div>
+    )
+  }
+  onContinue = () => {
+    swal.setActionValue({ cancel: true })
+    swal.close()
+  }
+  onCancel = () => swal.close()
+  renderButtons() {
+    const { isSynced } = this.props.networkState
+    return (
+      <div>
+        <button className="secondary" onClick={this.onCancel}>Cancel</button>
+        <button
+          className="button-on-right"
+          onClick={this.onContinue}
+          disabled={false}
+        >Continue {!isSynced && <FontAwesomeIcon icon={['far', 'spinner-third']} spin />}
+        </button>
+      </div>
+    )
+  }
+  render() {
+    return (
+      <div>
+        {this.renderPartialNetworkStatus()}
+        <p style={{ margin: 40 }}>
+          Once you are fully synced with the network, the &quot;continue&quot;
+          button will become enabled
+        </p>
+        {this.renderButtons()}
+      </div>
+    )
+  }
+}
+
+function getModalContent() {
+  const wrapper = document.createElement('div')
+  ReactDOM.render(<ProtectWhenSyncincModal networkState={networkState} />, wrapper)
+  return wrapper.firstChild
+}

--- a/app/states/network-state.js
+++ b/app/states/network-state.js
@@ -9,7 +9,7 @@ class NetworkState {
   @observable difficulty = 0
   @observable medianTime = 0
   @observable connections = 0
-  @observable initialBlockDownload = true
+  @observable isSynced = true
   @observable connectedToNode = false
 
   constructor() {
@@ -32,7 +32,7 @@ class NetworkState {
         this.headers = result.headers
         this.difficulty = result.difficulty
         this.medianTime = result.medianTime
-        this.initialBlockDownload = result.initialBlockDownload
+        this.isSynced = result.initialBlockDownload
         this.connectedToNode = true
       })
     } catch (error) {
@@ -45,6 +45,10 @@ class NetworkState {
     runInAction(() => {
       this.connections = networkConnectionsResult
     })
+  }
+
+  get isSyncing() {
+    return this.isSynced || (this.blocks < this.headers)
   }
 }
 

--- a/app/states/network-state.js
+++ b/app/states/network-state.js
@@ -32,7 +32,7 @@ class NetworkState {
         this.headers = result.headers
         this.difficulty = result.difficulty
         this.medianTime = result.medianTime
-        this.isSynced = result.initialBlockDownload
+        this.isSynced = !result.initialBlockDownload
         this.connectedToNode = true
       })
     } catch (error) {
@@ -48,7 +48,7 @@ class NetworkState {
   }
 
   get isSyncing() {
-    return this.isSynced || (this.blocks < this.headers)
+    return !this.isSynced || (this.blocks < this.headers)
   }
 }
 


### PR DESCRIPTION
- simplify and clarify `netowrkState`
- create `enforceSynced` service
- wrap write operations (send, deploy contract, run contract) with `enforceSynced`. If the node isn't fully synced, a modal will popup with explanation, sync details, and option to continue with the write operation once the node has been synced.

NOTE
===
I'm aware the UI isn't great. I'm submitting this for review to make sure the logic is agreeable by everybody before we polish this.