### PR TITLE
Send crash reports to backtrace

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,8 +2,11 @@ import React from 'react'
 import { render } from 'react-dom'
 import { AppContainer } from 'react-hot-loader'
 
+import initCrashReporterForRenderer from './utils/crashReporter/crashReporterRendererProcess'
 import App from './App'
 import './app.scss'
+
+initCrashReporterForRenderer()
 
 render(
   <AppContainer>

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -14,8 +14,11 @@ import path from 'path'
 
 import { app, BrowserWindow } from 'electron'
 
+import initCrashReporterForMain from './utils/crashReporter/crashReporterMainProcess'
 import ZenNode from './ZenNode'
 import db from './services/store'
+
+initCrashReporterForMain()
 
 const isUiOnly = (process.env.UIONLY || process.argv.indexOf('--uionly') > -1 || process.argv.indexOf('uionly') > -1)
 
@@ -125,3 +128,4 @@ function saveWindowDimensionsToDb() {
   const { width, height } = mainWindow.getBounds()
   db.get('userPreferences').assign({ width, height }).write()
 }
+

--- a/app/utils/crashReporter/crashReporterMainProcess.js
+++ b/app/utils/crashReporter/crashReporterMainProcess.js
@@ -1,0 +1,9 @@
+import { crashReporter } from 'electron'
+
+import { crashReporterOpts } from './crashReporterShared'
+
+export default initCrashReporterForMain
+
+function initCrashReporterForMain() {
+  crashReporter.start(crashReporterOpts)
+}

--- a/app/utils/crashReporter/crashReporterRendererProcess.js
+++ b/app/utils/crashReporter/crashReporterRendererProcess.js
@@ -1,0 +1,11 @@
+import { crashReporter } from 'electron'
+import btRenderer from 'backtrace-js'
+
+import { crashReporterOpts, endpoint, token, attributes } from './crashReporterShared'
+
+export default initCrashReporterForRenderer
+
+function initCrashReporterForRenderer() {
+  btRenderer.initialize({ endpoint, token, attributes })
+  crashReporter.start(crashReporterOpts)
+}

--- a/app/utils/crashReporter/crashReporterShared.js
+++ b/app/utils/crashReporter/crashReporterShared.js
@@ -1,0 +1,17 @@
+import pjson from '../../package.json'
+
+export const endpoint = 'https://zenprotocol.sp.backtrace.io:8443'
+export const token = '3951a92f3c2901f77b728dfadd9539d6120d3fa23d709ccc7980564dda045004'
+export const attributes = {
+  NODE_ENV: process.env.NODE_ENV,
+  walletVersion: pjson.version,
+  zenNodeVersion: pjson.dependencies['@zen/zen-node'],
+}
+
+export const crashReporterOpts = {
+  productName: 'ZenProtocol',
+  companyName: 'zenwallet',
+  submitURL: `${endpoint}/post?format=minidump&token=${token}`,
+  uploadToServer: true,
+  extra: attributes,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2288,6 +2288,11 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
+    "backtrace-js": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/backtrace-js/-/backtrace-js-0.0.10.tgz",
+      "integrity": "sha512-GDHpjowv155CE7+7gHp6vHir5EEZ1pKQPTY1lA1d3cT75h5L8/5lbN34I57YA/t5Mii/eitBZGyVbnRGjNVIqg=="
+    },
     "bail": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
@@ -7970,6 +7975,7 @@
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
   "dependencies": {
     "@zen/zen-node": "0.3.33",
     "axios": "^0.18.0",
+    "backtrace-js": "0.0.10",
     "bech32": "^1.1.3",
     "bip39": "^2.5.0",
     "bs58": "^4.0.1",


### PR DESCRIPTION
- send electron crash reports to [backtrace](https://documentation.backtrace.io/product_integration_minidump_electron/)
- send uncaught renderer errors to backtrace 

I'm still waiting for an answer from their dev support about the backtrace that is send with the crash reports.

We can merge it for now, and if needed add changes later.