### PR TITLE
smoother UI startup

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -21,7 +21,9 @@ export default class App extends React.Component {
             <React.Fragment>
               <AppUpdater />
               <Idle />
-              <Routes />
+              <div className="app-wrapper">
+                <Routes />
+              </div>
               <ModalContainer />
             </React.Fragment>
           </Provider>

--- a/app/app.scss
+++ b/app/app.scss
@@ -12,6 +12,7 @@
  @import "styles/Reset";
  @import "styles/Variables";
  @import "styles/Shared";
+ @import "styles/KeyFrames";
  @import "styles/Swal";
  @import "styles/Table";
  @import "styles/Buttons";
@@ -48,5 +49,10 @@
  @import "components/OnBoarding/SecretPhraseQuiz/SecretPhraseQuiz";
  @import "components/OnBoarding/SetPassword/SetPassword";
  @import "components/OnBoarding/TermsOfService/TermsOfService";
- //
+ 
  #root { height: 100%; }
+
+.app-wrapper {
+  height: 100%;
+  animation: fadein 0.5s;
+}

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -117,6 +117,7 @@ function getMainWindow(title) {
     width,
     height,
     title,
+    backgroundColor: '#121212',
   })
 }
 

--- a/app/styles/_KeyFrames.scss
+++ b/app/styles/_KeyFrames.scss
@@ -1,0 +1,8 @@
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
- initialize window in same background color of app
- fade in UI

The app used to load a white screen, and then replaced with our UI with a dark gray/black background.

Now it fires up directly in the same background color, and the UI fades in.