### PR TITLE
fix UI jump when navigating to page with scrollbar

### DIFF
--- a/app/app.scss
+++ b/app/app.scss
@@ -50,3 +50,7 @@
  @import "components/OnBoarding/TermsOfService/TermsOfService";
  //
  #root { height: 100%; }
+
+ html {
+  overflow-y: scroll;
+}


### PR DESCRIPTION
display the scrollbar at all times, so when navigating to long pages (i.e. transactions/blockchain logs) the UI doesn't "jump" to squeeze in the scrollbar