### PR TITLE
Patrick: Disable delete button from saved contract list if the contract exists as an asset in the user's balances

### DIFF
--- a/app/components/SavedContracts/SavedContracts.js
+++ b/app/components/SavedContracts/SavedContracts.js
@@ -70,6 +70,15 @@ class SavedContracts extends Component<Props, State> {
   }
 
   onDeleteClicked = async (contractId: string) => {
+    const cannotDelete = this.contractExistsInAssets(contractId)
+    if (cannotDelete) {
+      await swal({
+        title: 'can\'t delete contract',
+        text: 'you have a matching asset for this contract in your portfolio',
+        icon: 'warning',
+      })
+      return
+    }
     const userConfirmedDelete = await swal({
       title: 'Are you sure?',
       text: 'Are you sure that you want to delete this contract?',
@@ -102,15 +111,11 @@ class SavedContracts extends Component<Props, State> {
     return aExpire - bExpire
   }
 
-  contractExistsInAssets = (contract: SavedContract): boolean =>
-    this.props.balances.assets.find(a => a.asset === contract.contractId) !== undefined
+  contractExistsInAssets = (contractId: string): boolean =>
+    !!this.props.balances.assets.find(a => a.asset === contractId)
 
   renderSavedContractRow = (savedContract: SavedContract) => {
-    const cannotDelete = this.contractExistsInAssets(savedContract)
-    const callDeleteContract = cannotDelete ? null : () => {
-      this.onDeleteClicked(savedContract.contractId)
-    }
-
+    const cannotDelete = this.contractExistsInAssets(savedContract.contractId)
     return (
       <Fragment key={savedContract.contractId}>
         <tr key={savedContract.contractId}>
@@ -141,8 +146,9 @@ class SavedContracts extends Component<Props, State> {
             {
               <a
                 className="button small alert"
-                aria-disabled={cannotDelete ? 'true' : 'false'}
-                onClick={callDeleteContract}
+                aria-disabled={String(cannotDelete)}
+                onClick={() => this.onDeleteClicked(savedContract.contractId)}
+                title={cannotDelete ? 'Cant delete contract with matching asset (click for details)' : ''}
               >
                 <FontAwesomeIcon icon={['far', 'trash']} />
               </a>

--- a/app/components/SavedContracts/SavedContracts.js
+++ b/app/components/SavedContracts/SavedContracts.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component, Fragment } from 'react'
+import * as React from 'react'
 import { inject, observer } from 'mobx-react'
 import { Link } from 'react-router-dom'
 import Flexbox from 'flexbox-react'
@@ -9,16 +9,19 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import cx from 'classnames'
 
 import ActiveContractSetState from '../../states/acs-state'
+import BalancesState from '../../states/balances-state'
 import ContractMessageState from '../../states/contract-message'
 import ContractState from '../../states/contract-state'
 import Layout from '../UI/Layout/Layout'
 import CopyableTableCell from '../UI/CopyableTableCell'
 import db from '../../services/store'
 
+const { Component, Fragment } = React
 type Props = {
   activeContractSet: ActiveContractSetState,
   contractMessage: ContractMessageState,
-  contract: ContractState
+  contract: ContractState,
+  balances: BalancesState
 };
 
 type State = {
@@ -29,15 +32,23 @@ type SavedContract = {
   contractId: string,
   address: string,
   code: string,
-  isActive?: boolean,
-  isCodeCurrentlyViewed?: boolean,
-  expire?: number,
+  isActive: boolean,
+  isCodeCurrentlyViewed: boolean,
+  expire: number,
+  name: string
+};
+
+type DBSavedContract = {
+  contractId?: string,
+  address?: string,
+  code?: string,
   name?: string
 };
 
 @inject('contract')
 @inject('contractMessage')
 @inject('activeContractSet')
+@inject('balances')
 @observer
 class SavedContracts extends Component<Props, State> {
   state = {
@@ -72,76 +83,94 @@ class SavedContracts extends Component<Props, State> {
     }
   }
 
-  addExpiryToSavedContract = (savedContract: SavedContract) => {
+  addRequiredFieldsToSavedContract = (savedContract: DBSavedContract): SavedContract => {
     const matchingActiveContract = this.props.activeContractSet.activeContracts
       .find(ac => ac.contractId === savedContract.contractId) || {}
     return {
       ...savedContract,
+      code: savedContract.code || '',
+      name: savedContract.name || '',
       expire: matchingActiveContract.expire || 0,
       isActive: !!matchingActiveContract.expire,
+      isCodeCurrentlyViewed: this.state.showCodeSnippetForContractAddress === savedContract.address,
     }
   }
-  addIsCodeCurrentlyViewedToSavedContract = (savedContract: SavedContract) => ({
-    ...savedContract,
-    isCodeCurrentlyViewed: this.state.showCodeSnippetForContractAddress === savedContract.address,
-  })
-  // $FlowFixMe
-  sortSavedContractsByExpiry = (a: SavedContract, b: SavedContract) => a.expire < b.expire
 
-  renderSavedContractRow = (savedContract: SavedContract) => (
-    <Fragment key={savedContract.contractId}>
-      <tr key={savedContract.contractId}>
-        <td className="text">{savedContract.name}</td>
-        <CopyableTableCell string={savedContract.contractId} />
-        <CopyableTableCell string={savedContract.address} />
-        {/* $FlowFixMe */}
-        <td>{ savedContract.isActive ? savedContract.expire.toLocaleString() : 'Inactive' }</td>
-        <td className="align-right buttons">
-          <a
-            title="Toggle Code Snippet"
-            onClick={() => { this.toggleCodeSnippet(savedContract.address) }}
-            className="button secondary small margin-right code"
-          >
-            <FontAwesomeIcon icon={['far', 'code']} /> <span className="button-text">Code</span>
-          </a>
-          {
+  sortSavedContractsByExpiry = (a: SavedContract, b: SavedContract): number => {
+    const aExpire = a.expire || Number.MAX_VALUE
+    const bExpire = b.expire || Number.MAX_VALUE
+    return aExpire - bExpire
+  }
+
+  contractExistsInAssets = (contract: SavedContract): boolean =>
+    this.props.balances.assets.find(a => a.asset === contract.contractId) !== undefined
+
+  renderSavedContractRow = (savedContract: SavedContract) => {
+    const cannotDelete = this.contractExistsInAssets(savedContract)
+    const callDeleteContract = cannotDelete ? null : () => {
+      this.onDeleteClicked(savedContract.contractId)
+    }
+
+    return (
+      <Fragment key={savedContract.contractId}>
+        <tr key={savedContract.contractId}>
+          <td className="text">{savedContract.name}</td>
+          <CopyableTableCell string={savedContract.contractId} />
+          <CopyableTableCell string={savedContract.address} />
+          <td>{ savedContract.isActive ? savedContract.expire.toLocaleString() : 'Inactive' }</td>
+          <td className="align-right buttons">
+            <a
+              title="Toggle Code Snippet"
+              onClick={() => { this.toggleCodeSnippet(savedContract.address) }}
+              className="button secondary small margin-right code"
+            >
+              <FontAwesomeIcon icon={['far', 'code']} /> <span className="button-text">Code</span>
+            </a>
+            {
             savedContract.isActive ?
               (
                 <Link title="Run Contract" className="button small play margin-right play-upload-button" to="/run-contract" onClick={() => this.props.contractMessage.updateAddress(savedContract.address)}>
                   <FontAwesomeIcon icon={['far', 'play']} /> <span className="button-text">Run</span>
                 </Link>
               ) : (
-                // $FlowFixMe
                 <Link className="button small margin-right play-upload-button" to="/activate-contract" title="Upload Contract" onClick={() => { this.props.contract.prepareToUploadSavedContract(savedContract.name, savedContract.code) }}>
                   <FontAwesomeIcon icon={['far', 'cloud-upload']} /> <span className="button-text">Upload</span>
                 </Link>
               )
           }
-          <a className="button small alert" onClick={() => { this.onDeleteClicked(savedContract.contractId) }}>
-            <FontAwesomeIcon icon={['far', 'trash']} />
-          </a>
-        </td>
-      </tr>
-      <tr className={cx('code', { 'display-none': !savedContract.isCodeCurrentlyViewed })}>
-        <td colSpan="5">
-          <Flexbox flexDirection="column" className="contract-code form-row">
-            <Highlight className="fsharp">
-              {savedContract.code}
-            </Highlight>
-          </Flexbox>
-        </td>
-      </tr>
-      <tr className="separator" />
-    </Fragment>
-  )
-  renderSavedContractsRows() {
-    const savedContracts = db.get('savedContracts').value()
+            {
+              <a
+                className="button small alert"
+                aria-disabled={cannotDelete ? 'true' : 'false'}
+                onClick={callDeleteContract}
+              >
+                <FontAwesomeIcon icon={['far', 'trash']} />
+              </a>
+          }
+          </td>
+        </tr>
+        <tr className={cx('code', { 'display-none': !savedContract.isCodeCurrentlyViewed })}>
+          <td colSpan="5">
+            <Flexbox flexDirection="column" className="contract-code form-row">
+              <Highlight className="fsharp">
+                {savedContract.code}
+              </Highlight>
+            </Flexbox>
+          </td>
+        </tr>
+        <tr className="separator" />
+      </Fragment>
+    )
+  }
+
+  renderSavedContractsRows(): React.Node[] {
+    const savedContracts: DBSavedContract[] = db.get('savedContracts').value()
     return savedContracts
-      .map(this.addExpiryToSavedContract)
-      .map(this.addIsCodeCurrentlyViewedToSavedContract)
+      .map(this.addRequiredFieldsToSavedContract)
       .sort(this.sortSavedContractsByExpiry)
       .map(this.renderSavedContractRow)
   }
+
   render() {
     return (
       <Layout className="saved-contracts">

--- a/app/components/SavedContracts/SavedContracts.js
+++ b/app/components/SavedContracts/SavedContracts.js
@@ -73,8 +73,8 @@ class SavedContracts extends Component<Props, State> {
     const cannotDelete = this.contractExistsInAssets(contractId)
     if (cannotDelete) {
       await swal({
-        title: 'can\'t delete contract',
-        text: 'you have a matching asset for this contract in your portfolio',
+        title: 'Can\'t delete contract',
+        text: 'You have a matching asset for this contract in your portfolio.',
         icon: 'warning',
       })
       return

--- a/app/components/SavedContracts/SavedContracts.scss
+++ b/app/components/SavedContracts/SavedContracts.scss
@@ -2,7 +2,15 @@
 .saved-contracts-container {
 
   table tbody td.buttons {
-    .button { height: 29px; }
+    .button {
+      height: 29px;
+      &[aria-disabled="true"] {
+        background-color: $button-grey-disabled;
+        color: white;
+        cursor: not-allowed;
+        border: 1px solid $button-grey-disabled;
+      }
+    }
     min-width: 220px;
   }
 

--- a/app/components/SavedContracts/SavedContracts.scss
+++ b/app/components/SavedContracts/SavedContracts.scss
@@ -5,10 +5,8 @@
     .button {
       height: 29px;
       &[aria-disabled="true"] {
-        background-color: $button-grey-disabled;
-        color: white;
         cursor: not-allowed;
-        border: 1px solid $button-grey-disabled;
+        opacity: 0.5;
       }
     }
     min-width: 220px;

--- a/app/components/SavedContracts/__tests__/SavedContract.spec.js
+++ b/app/components/SavedContracts/__tests__/SavedContract.spec.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import states from '../../../states'
+import SavedContracts from '../SavedContracts'
+
+jest.mock('electron', () => ({
+  app: {
+    getPath() { return 'test' },
+  },
+  ipcRenderer: { send: jest.fn(), on: jest.fn() },
+}))
+
+describe('SavedContracts', () => {
+  describe('sortSavedContractsByExpiry', () => {
+    const UnWrappedComponent =
+      SavedContracts.wrappedComponent.wrappedComponent.wrappedComponent.wrappedComponent
+    const component = shallow(<UnWrappedComponent {...states} />)
+    const sortFunction = component.instance().sortSavedContractsByExpiry
+    describe('when contracts contain data with undefined expiry', () => {
+      const a = { address: 'a', expire: 900 }
+      const b = { address: 'b' }
+      const c = { address: 'c' }
+      const d = { address: 'd', expire: 90 }
+      it('returns contracts in ascending order of expiry and with undefined expiry last', () => {
+        const contracts = [a, b, c, d]
+        contracts.sort(sortFunction)
+        expect(contracts).toEqual([d, a, b, c])
+      })
+    })
+
+    describe('when contracts contain data without undefined expiry', () => {
+      const a = { address: 'a', expire: 900 }
+      const b = { address: 'b', expire: 890 }
+      const c = { address: 'c', expire: 1000 }
+      const d = { address: 'd', expire: 90 }
+      it('returns contracts in ascending order of expiry', () => {
+        const contracts = [a, b, c, d]
+        contracts.sort(sortFunction)
+        expect(contracts).toEqual([d, b, a, c])
+      })
+    })
+  })
+})

--- a/app/components/TxHistory/TxHistory.js
+++ b/app/components/TxHistory/TxHistory.js
@@ -7,7 +7,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import Layout from '../UI/Layout/Layout'
 import OnScrollBottom from '../UI/OnScrollBottom'
 import CopyableTableCell from '../UI/CopyableTableCell'
-import TransactionHistoryState, { type ObservableTransactionResponse } from '../../states/tx-history-state'
+import TransactionHistoryState from '../../states/tx-history-state'
 
 import SingleTxDelta from './SingleTxDelta'
 
@@ -26,37 +26,10 @@ class TxHistory extends Component<Props> {
     this.props.txhistory.reset()
   }
 
-  renderTransactionsCell(tx: ObservableTransactionResponse) {
-    // $FlowFixMe
-    if (tx.deltas.length === 1) {
-      return (
-        <SingleTxDelta tx={tx.deltas[0]} />
-      )
-    }
-
-    if (tx.deltas.length > 1) {
-      const deltasRows = tx.deltas.reverse().map(t => (
-        <tr key={t.asset}>
-          <SingleTxDelta tx={t} />
-        </tr>
-      ))
-
-      return (
-        <td colSpan="3" className="multiple-inner-tx-deltas">
-          <table>
-            <tbody>
-              {deltasRows}
-            </tbody>
-          </table>
-        </td>
-      )
-    }
-  }
-
   renderRows() {
     const { txhistory } = this.props
-    return txhistory.transactions.map(tx => (
-      <Fragment key={tx.txHash}>
+    return txhistory.transactions.map((tx, index) => (
+      <Fragment key={`${tx.txHash}-${index}`}>
         <tr>
           <CopyableTableCell string={tx.txHash} />
           <SingleTxDelta tx={tx} />
@@ -67,7 +40,7 @@ class TxHistory extends Component<Props> {
   }
 
   renderLoadingTransactions() {
-		return (
+    return (
       <tr className="loading-transactions">
         <td colSpan={5}>
           <Flexbox>
@@ -101,7 +74,8 @@ class TxHistory extends Component<Props> {
             </thead>
             <tbody>
               { this.renderRows() }
-              { txhistory.isFetching && (txhistory.transactions.length > 20) && this.renderLoadingTransactions() }
+              { txhistory.isFetching &&
+                (txhistory.transactions.length > 20) && this.renderLoadingTransactions() }
             </tbody>
           </table>
         </Flexbox>


### PR DESCRIPTION
This also addresses any inconsistencies that may have existed in the way saved contracts are sorted. In particular when saved contracts are inactive (or have no expiry date set).

Feedback welcome on the color of the disabled button. It uses the existing disabled button color variable. 

Added by @goldylucks
- disable deleting saved contract with matching asset in balances
- display modal explaining why contract can't be deleted
- improve flow annotations
- fix transactions duplicate key bug
- add tests