### PR TITLE
add wipe release flag support

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -5,6 +5,7 @@ import ErrorBoundary from 'react-error-boundary'
 
 import ErrorScreen from './components/ErrorScreen'
 import AppUpdater from './components/AppUpdater/AppUpdater'
+import WipeModal from './components/UI/WipeModal'
 import Idle from './components/Idle'
 import ModalContainer from './components/ModalContainer'
 import history from './services/history'
@@ -20,6 +21,7 @@ export default class App extends React.Component {
           <Provider history={history} {...states}>
             <React.Fragment>
               <AppUpdater />
+              <WipeModal />
               <Idle />
               <div className="app-wrapper">
                 <Routes />

--- a/app/components/UI/Sidebar/Sidebar.js
+++ b/app/components/UI/Sidebar/Sidebar.js
@@ -4,7 +4,7 @@ import { inject, observer } from 'mobx-react'
 import { Link, NavLink } from 'react-router-dom'
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 
-import pjson from '../../../../package.json'
+import { ZEN_NODE_VERSION, WALLET_VERSION } from '../../../constants/versions'
 import { LOGO_SRC } from '../../../constants/imgSources'
 import NetworkState from '../../../states/network-state'
 import SecretPhraseState from '../../../states/secret-phrase-state'
@@ -82,11 +82,11 @@ class Sidebar extends Component<Props> {
       <React.Fragment>
         <div className="network-data-point">
           <span className="data-name" title="Wallet Version">Wallet Version: </span>
-          <span className="data-point">{pjson.version}</span>
+          <span className="data-point">{WALLET_VERSION}</span>
         </div>
         <div className="network-data-point">
           <span className="data-name" title="Node Version">Node Version: </span>
-          <span className="data-point">{pjson.dependencies['@zen/zen-node']}</span>
+          <span className="data-point">{ZEN_NODE_VERSION}</span>
         </div>
       </React.Fragment>
     )

--- a/app/components/UI/WipeModal.js
+++ b/app/components/UI/WipeModal.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import swal from 'sweetalert'
+import { ipcRenderer } from 'electron'
+
+import { WALLET_VERSION } from '../../constants/versions'
+import { IPC_ASK_IF_WIPED_DUE_TO_VERSION, IPC_ANSWER_IF_WIPED_DUE_TO_VERSION } from '../../ZenNode'
+
+class WipeModal extends React.Component {
+  componentDidMount() {
+    ipcRenderer.send(IPC_ASK_IF_WIPED_DUE_TO_VERSION)
+    ipcRenderer.once(IPC_ANSWER_IF_WIPED_DUE_TO_VERSION, (evt, flag) => {
+      if (flag) {
+        this.initModal()
+      }
+    })
+  }
+  initModal() {
+    swal({
+      title: 'Local wipe occured',
+      text: `Your new version of the zen wallet (${WALLET_VERSION}) requires a local chain wipe, so we automatically did it for you. Sit back while your local node is being synced with the network (see syncing progress in the bottom left portion of the secreen)`,
+    })
+  }
+  render() {
+    return null
+  }
+}
+
+export default WipeModal

--- a/app/constants/versions.js
+++ b/app/constants/versions.js
@@ -1,0 +1,4 @@
+import pjson from '../../package.json'
+
+export const WALLET_VERSION = pjson.version
+export const ZEN_NODE_VERSION = pjson.dependencies['@zen/zen-node']

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -43,6 +43,11 @@ db.defaults({
     isReportingErrors: false,
     dontAskToReportErrors: false,
   },
+  lastWipe: {
+    timestamp: null,
+    walletVersion: null,
+    zenNodeVersion: null,
+  },
 }).write()
 
 export default db

--- a/internals/scripts/PrintZenNodeVersion.js
+++ b/internals/scripts/PrintZenNodeVersion.js
@@ -1,3 +1,3 @@
-import pjson from '../../package.json'
+import { ZEN_NODE_VERSION } from '../../app/constants/versions'
 
-console.log('zen node version:', pjson.dependencies['@zen/zen-node'])
+console.log('zen node version:', ZEN_NODE_VERSION)


### PR DESCRIPTION
- save to DB last version in which wipe occurred
- when starting zen node, automatically add `wipe` if latest required version is greater than saved version
- show modal about automatic wipe if occured
- add constants `WALLET_VERSION` and `ZEN_NODE_VERSION`