### PR TITLE
fix windows mining toggle, wipe, and dev

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -7,6 +7,13 @@ $ npm run postinstall-dev
 $ npm run dev # first time it will take a while to sync the blockchain
 ```
 
+#### Windows potential errors
+`node-sass`: if you see this error in your terminal:  
+Error: ENOENT: no such file or directory, scandir '/Users/blinkyang/test/tmp/test-node-sass/node_modules/node-sass/vendor'  
+`$ npm rebuild node-sass` should fix it. Further details [here](https://github.com/sass/node-sass/issues/1812)  
+`electron`: if you see an error regarding electron not found or `ENONET` and electron somewhere in it, installing it globally should fix the issue: `$ npm install -g electron`  
+When producing local installer, if you see `'build' is not recognized`, installing `electron-builder` globally should fix the issue: `$ npm install -g electron-builder`. If a similar error occurs for `concurrently`, run `$ npm install -g concurrently` to solve that.
+
 # Updating zen node
 It's best to update the zen node and commit ONLY that change, to make it easy to trace in the repo's graph
 ```bash

--- a/app/ZenNode.js
+++ b/app/ZenNode.js
@@ -12,7 +12,7 @@ import db from './services/store'
 
 export const IPC_RESTART_ZEN_NODE = 'restartZenNode'
 export const IPC_BLOCKCHAIN_LOGS = 'blockchainLogs'
-export const ZEN_NODE_RESTART_SIGNAL = 'SIGUSR1'
+export const ZEN_NODE_RESTART_SIGNAL = 'SIGKILL'
 
 class ZenNode {
   node = {
@@ -100,12 +100,12 @@ export default ZenNode
 function getZenNodePath() {
   return isInstalledWithInstaller()
     // $FlowFixMe
-    ? path.join(process.resourcesPath, '/node_modules/@zen/zen-node')
-    : path.join(__dirname, '../node_modules/@zen/zen-node')
+    ? path.join(process.resourcesPath, 'node_modules', '@zen', 'zen-node')
+    : path.join(__dirname, '..', 'node_modules', '@zen', 'zen-node')
 }
 
 function isInstalledWithInstaller() {
-  return !process.resourcesPath.includes('node_modules/electron/dist')
+  return !process.resourcesPath.includes(path.join('node_modules', 'electron', 'dist'))
 }
 
 export function getInitialIsMining() {


### PR DESCRIPTION
- change restart signal to SIGKILL (windows doesn't support SIGUSER1)
- use path.join to handle path slashes (windows uses inconsistent forward and backslashes)
- add workarounds for windows dev errors to `README_DEV`

This might fix npm on windows, if not, fixing the path(s) on the zen node package, `zen-node/index.js`, should do the trick