### PR TITLE
init error store before others

### DIFF
--- a/app/states/index.js
+++ b/app/states/index.js
@@ -12,6 +12,9 @@ import BlockchainLogsState from './blockchain-logs-state'
 import ModalState from './modal-state'
 import ErrorReportingState from './error-reporting-state'
 
+const errorReportingState = new ErrorReportingState()
+errorReportingState.init()
+
 const activeContractSet = new ActiveContractSetState()
 const balances = new BalancesState(activeContractSet)
 const publicAddress = new PublicAddressState()
@@ -24,9 +27,6 @@ const contractMessage = new ContractMessage(activeContractSet)
 const redeemTokensState = new RedeemTokensState()
 const blockchainLogsState = new BlockchainLogsState()
 const modalState = new ModalState()
-const errorReportingState = new ErrorReportingState()
-
-errorReportingState.init()
 
 export default {
   balances,


### PR DESCRIPTION
two reasons for doing this:
1. it will catch initializing errors of other stores
1. we got an error from a user about the `errorReportingState` not being initialized. The error came from the `PollManager` of the `networkState` store. I don't know why this happened, but maybe this will prevent future occurrences of that.