### PR TITLE
fix tx history loading and tests

### DIFF
--- a/app/components/TxHistory/TxHistory.js
+++ b/app/components/TxHistory/TxHistory.js
@@ -74,8 +74,7 @@ class TxHistory extends Component<Props> {
             </thead>
             <tbody>
               { this.renderRows() }
-              { txhistory.isFetching &&
-                (txhistory.transactions.length > 20) && this.renderLoadingTransactions() }
+              { txhistory.isFetching && this.renderLoadingTransactions() }
             </tbody>
           </table>
         </Flexbox>

--- a/app/states/__tests__/tx-history-state.spec.js
+++ b/app/states/__tests__/tx-history-state.spec.js
@@ -81,8 +81,8 @@ describe('TxHistoryState', () => {
           txHistoryState.fetch()
         })
 
-        it('calls getTxHistory with skip: 0 and take: 20', () => {
-          expect(getTxHistory).toHaveBeenCalledWith({ skip: 0, take: 20 })
+        it('calls getTxHistory with skip: 0 and take: txHistoryState.batchSize', () => {
+          expect(getTxHistory).toHaveBeenCalledWith({ skip: 0, take: txHistoryState.batchSize })
         })
         it('sets isFetching to true', () => {
           expect(txHistoryState.isFetching).toBe(true)

--- a/app/states/tx-history-state.js
+++ b/app/states/tx-history-state.js
@@ -1,7 +1,7 @@
 // @flow
 import { observable, action, runInAction, type IObservableArray } from 'mobx'
 
-import { getTxHistory, type TransactionDelta } from '../services/api-service'
+import { getTxHistory } from '../services/api-service'
 import PollManager from '../utils/PollManager'
 
 export type ObservableTransactionResponse = {
@@ -11,9 +11,8 @@ export type ObservableTransactionResponse = {
   confirmations: number
 };
 
-const BATCH_SIZE = 100
-
 class TxHistoryState {
+  @observable batchSize = 100
   @observable transactions: IObservableArray<ObservableTransactionResponse> = observable.array([])
   @observable skip = 0
   @observable currentPageSize = 0
@@ -22,7 +21,7 @@ class TxHistoryState {
 
   constructor() {
     this.fetchPollManager = new PollManager({
-      name: 'ACS fetch',
+      name: 'tx history fetch',
       fnToPoll: this.fetch,
       timeoutInterval: 5000,
     })
@@ -54,7 +53,7 @@ class TxHistoryState {
     this.isFetching = true
     try {
       const result = await getTxHistory({
-        skip: this.skip, take: this.currentPageSize + BATCH_SIZE,
+        skip: this.skip, take: this.currentPageSize + this.batchSize,
       })
       runInAction(() => {
         console.log('result', result)


### PR DESCRIPTION
- use batchSize property instead of magic number 20
- show loading if is fetching transactions (changed the check [here](https://github.com/zenprotocol/zenwallet/compare/master...goldylucks:transaction-loading-fix?expand=1#diff-93fafaef324fe1c013c073527adb65bcL78), @thehogfather if we are fetching, why do we need that second check?)

We changed the batch number from 20 to 100, and the "20" was hard coded in some places.