### PR TITLE
Custom ZEN_API port

### DIFF
--- a/app/ZenNode.js
+++ b/app/ZenNode.js
@@ -112,6 +112,11 @@ class ZenNode {
     if (net) {
       args.push('--chain', net)
     }
+    if (process.env.ZEN_NODE_API_PORT) {
+      args.push('--api', `127.0.0.1:${process.env.ZEN_NODE_API_PORT}`)
+    }
+
+
     shout('[ZEN NODE]: Zen node args', args)
     return args
   }

--- a/app/config/server-address.js
+++ b/app/config/server-address.js
@@ -16,6 +16,9 @@ function onSwitchChain(evt, newChain) {
 }
 
 export const getServerAddress = () => {
+  if (process.env.ZEN_NODE_API_PORT) {
+    return `${localhost}:${process.env.ZEN_NODE_API_PORT}`
+  }
   if (chain === 'local') {
     return `${localhost}:${LOCAL_NET_PORT}`
   }


### PR DESCRIPTION
Some machines have the default port taken.

This allow to set a custom port for the API.