### PR TITLE
attempt to fix windows run as admin

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       ]
     },
     "win": {
-      "requestedExecutionLevel": "highestAvailable",
+      "requestedExecutionLevel": "requireAdministrator",
       "target": [
         "nsis"
       ]


### PR DESCRIPTION
Before merging, please try this workaround: https://www.askvg.com/this-file-does-not-have-a-program-associated-with-it-error-message-while-running-a-game-from-game-explorer-in-windows-vista/