### PR TITLE
Improve seed logic

### DIFF
--- a/app/components/Icons/IsValidIcon.js
+++ b/app/components/Icons/IsValidIcon.js
@@ -8,7 +8,7 @@ const IsValidIcon = ({
 }) => (
   <FontAwesomeIcon
     icon={['far', isValid ? 'check' : 'times']}
-    className={cx(className, { 'display-none': isHidden, error: hasColors && !isValid, valid: hasColors && isValid })}
+    className={cx(className, 'is-valid-icon', { 'display-none': isHidden, error: hasColors && !isValid, valid: hasColors && isValid })}
     {...rest}
   />
 )

--- a/app/components/Icons/ToggleVisibilityIcon.js
+++ b/app/components/Icons/ToggleVisibilityIcon.js
@@ -1,16 +1,23 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
+import cx from 'classnames'
 
-const ToggleVisibilityIcon = ({ shouldShow, ...rest }) => (
+const ToggleVisibilityIcon = ({ shouldShow, className, ...rest }) => (
   <FontAwesomeIcon
     icon={['far', shouldShow ? 'eye' : 'eye-slash']}
+    style={{ cursor: 'pointer' }}
+    className={cx(className, 'toggle-input-visibility-icon')}
     {...rest}
   />
 )
 
 ToggleVisibilityIcon.propTypes = {
   shouldShow: PropTypes.bool.isRequired,
+  className: PropTypes.string,
+}
+ToggleVisibilityIcon.defaultProps = {
+  className: '',
 }
 
 export default ToggleVisibilityIcon

--- a/app/components/OnBoarding/ImportWallet/ImportWallet.js
+++ b/app/components/OnBoarding/ImportWallet/ImportWallet.js
@@ -62,11 +62,7 @@ class ImportWallet extends Component {
     return !!(word.length && !this.isInputPerfect(idx))
   }
 
-  validateSecretPhrase() {
-    return this.isEachWordAPerfectBip39Word && this.isValidBip39Mnemonic
-  }
-
-  get isEachWordAPerfectBip39Word() {
+  get areAllInputsPerfect() {
     return this.state.userInputWords.every(isBip39Word)
   }
   get isValidBip39Mnemonic() {
@@ -74,10 +70,10 @@ class ImportWallet extends Component {
     return bip39.validateMnemonic(mnemonicPhraseString)
   }
   get notValidBip39PhraseMessage() {
-    if (!this.isEachWordAPerfectBip39Word || this.isValidBip39Mnemonic) {
+    if (!this.areAllInputsPerfect || this.isValidBip39Mnemonic) {
       return
     }
-    return <p className="is-error" style={{ marginTop: 10 }}>This is not a valid bip39 Mnemonic Passphrase</p>
+    return <p className="is-error" style={{ marginTop: 10 }}>Each word is a valid bip39 word, but this is not a valid bip39 Mnemonic Passphrase</p>
   }
   reset = () => {
     this.setState({ userInputWords: getInitialInputsState() })
@@ -150,7 +146,7 @@ class ImportWallet extends Component {
             <button
               className="button-on-right"
               onClick={this.onSubmitClicked}
-              disabled={!this.validateSecretPhrase()}
+              disabled={!this.isValidBip39Mnemonic}
             >
               Continue
             </button>

--- a/app/components/OnBoarding/ImportWallet/ImportWallet.js
+++ b/app/components/OnBoarding/ImportWallet/ImportWallet.js
@@ -77,7 +77,7 @@ class ImportWallet extends Component {
     if (!this.isEachWordAPerfectBip39Word || this.isValidBip39Mnemonic) {
       return
     }
-    return <p className="is-error">This is not a valid bip39 Mnemonic Passphrase</p>
+    return <p className="is-error" style={{ marginTop: 10 }}>This is not a valid bip39 Mnemonic Passphrase</p>
   }
   reset = () => {
     this.setState({ userInputWords: getInitialInputsState() })
@@ -136,7 +136,7 @@ class ImportWallet extends Component {
         <div>
           <PasteButton onClick={this.paste} />
           <button onClick={this.reset} className="secondary button-on-right">
-            <FontAwesomeIcon icon={['far', 'trash']} />  Reset
+            <FontAwesomeIcon icon={['far', 'trash']} /> Reset
           </button>
         </div>
         {this.notValidBip39PhraseMessage}

--- a/app/components/OnBoarding/ImportWallet/ImportWallet.js
+++ b/app/components/OnBoarding/ImportWallet/ImportWallet.js
@@ -2,11 +2,10 @@ import React, { Component } from 'react'
 import { inject, observer } from 'mobx-react'
 import { Link } from 'react-router-dom'
 import Flexbox from 'flexbox-react'
-import cx from 'classnames'
 import bip39 from 'bip39'
 
+import SeedInput from '../../UI/SeedInput'
 import ExternalLink from '../../UI/ExternalLink'
-import IsValidIcon from '../../Icons/IsValidIcon'
 import history from '../../../services/history'
 import { isValidBip39Word, isBip39Word } from '../../../utils/helpers'
 import OnBoardingLayout from '../Layout/Layout'
@@ -14,17 +13,16 @@ import OnBoardingLayout from '../Layout/Layout'
 @inject('secretPhraseState')
 @observer
 class ImportWallet extends Component {
-  componentWillMount() {
+  componentDidMount() {
     const { secretPhraseState } = this.props
     secretPhraseState.mnemonicPhrase = [...Array(24).keys()].map(() => (
       { word: '', status: '' }
     ))
   }
 
-  onChange = (evt) => {
-    const index = Number(evt.target.getAttribute('data-index'))
+  onChangeIdx = (evt, idx) => {
     const newWord = evt.target.value.trim().toLowerCase()
-    const object = this.props.secretPhraseState.mnemonicPhrase[index]
+    const object = this.props.secretPhraseState.mnemonicPhrase[idx]
     object.word = newWord
 
     object.status = ''
@@ -63,8 +61,6 @@ class ImportWallet extends Component {
   onSubmitClicked = () => {
     const { secretPhraseState } = this.props
     const wordArray = secretPhraseState.mnemonicPhrase.map((word) => word.word)
-    console.log('onSubmitClicked wordArray', wordArray)
-
     if (this.validateSecretPhrase()) {
       secretPhraseState.mnemonicPhrase = wordArray
       history.push('/set-password')
@@ -73,18 +69,16 @@ class ImportWallet extends Component {
 
   render() {
     const { mnemonicPhrase } = this.props.secretPhraseState
-
-    const importPhraseInputs = mnemonicPhrase.map((word, index) => (
-      <li key={index} className={word.status} >
-        <input
-          type="text"
-          data-index={index}
-          className={cx(word.status, { incomplete: this.isWordIncomplete(index) })}
-          onChange={this.onChange}
-          value={word.word}
-        />
-        <IsValidIcon isValid={word.status === 'perfect'} isHidden={!word.status.match(/perfect|invliad/)} />
-      </li>
+    const importPhraseInputs = mnemonicPhrase.map((word, idx) => (
+      <SeedInput
+        key={`${idx}`}
+        value={word.word}
+        isPerfect={word.status.includes('perfect')}
+        isInvalid={word.status.includes('invalid')}
+        isValid={word.status.includes('valid')}
+        isIncomplete={this.isWordIncomplete(idx)}
+        onChange={evt => this.onChangeIdx(evt, idx)}
+      />
     ))
 
     return (

--- a/app/components/OnBoarding/SecretPhrase/SecretPhrase.js
+++ b/app/components/OnBoarding/SecretPhrase/SecretPhrase.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import Flexbox from 'flexbox-react'
 import Checkbox from 'rc-checkbox'
+import { clipboard } from 'electron'
+import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 
 import history from '../../../services/history'
 import OnBoardingLayout from '../Layout/Layout'
@@ -19,6 +21,7 @@ class SecretPhrase extends Component {
   }
   state = {
     checked: false,
+    shouldShowCopyMessage: false,
   }
 
   componentWillMount() {
@@ -32,9 +35,16 @@ class SecretPhrase extends Component {
   onNextClicked = () => {
     history.push('/secret-phrase-quiz')
   }
-
+  copyToClipboard = () => {
+    const { mnemonicPhrase } = this.props.secretPhraseState
+    clipboard.writeText(JSON.stringify(mnemonicPhrase))
+    this.setState({ shouldShowCopyMessage: true })
+    this.copyTimeout = setTimeout(() => {
+      this.setState({ shouldShowCopyMessage: false })
+    }, 2000)
+  }
   render() {
-    const { checked } = this.state
+    const { checked, shouldShowCopyMessage } = this.state
     const { mnemonicPhrase } = this.props.secretPhraseState
     return (
       <OnBoardingLayout className="secret-phrase-container" progressStep={2}>
@@ -48,6 +58,12 @@ class SecretPhrase extends Component {
           {mnemonicPhrase.map((word, idx) => (<li key={idx}>{word}</li>))}
         </ol>
         <p className="warning">If you lose this passphrase you will lose all assets in the wallet!</p>
+        <div>
+          <button onClick={this.copyToClipboard} className="secondary" style={{ marginRight: 10 }}>
+            <FontAwesomeIcon icon={['far', 'copy']} /> Copy to clipboard
+          </button>
+          {shouldShowCopyMessage && 'Copied!'}
+        </div>
         <div className="devider before-buttons" />
 
         <Flexbox flexDirection="row">

--- a/app/components/OnBoarding/SecretPhrase/SecretPhrase.js
+++ b/app/components/OnBoarding/SecretPhrase/SecretPhrase.js
@@ -23,10 +23,13 @@ class SecretPhrase extends Component {
     checked: false,
     shouldShowCopyMessage: false,
   }
-
   componentWillMount() {
     this.props.secretPhraseState.generateSeed()
   }
+  componentWillUnmount() {
+    clearTimeout(this.copyTimeout)
+  }
+  copyTimeout = null
 
   onToggleSecuredPassphrase = (evt) => {
     this.setState({ checked: evt.target.checked })

--- a/app/components/OnBoarding/SecretPhraseQuiz/SecretPhraseQuiz.js
+++ b/app/components/OnBoarding/SecretPhraseQuiz/SecretPhraseQuiz.js
@@ -108,7 +108,7 @@ class SecretPhraseQuiz extends Component {
         <div>
           <PasteButton onClick={this.paste} />
           <button onClick={this.reset} className="secondary button-on-right">
-            <FontAwesomeIcon icon={['far', 'trash']} />  Reset
+            <FontAwesomeIcon icon={['far', 'trash']} /> Reset
           </button>
         </div>
         <div className="devider before-buttons" />

--- a/app/components/OnBoarding/SecretPhraseQuiz/SecretPhraseQuiz.js
+++ b/app/components/OnBoarding/SecretPhraseQuiz/SecretPhraseQuiz.js
@@ -3,9 +3,8 @@ import { inject, observer } from 'mobx-react'
 import { Link } from 'react-router-dom'
 import Flexbox from 'flexbox-react'
 import _ from 'lodash'
-import cx from 'classnames'
 
-import IsValidIcon from '../../Icons/IsValidIcon'
+import SeedInput from '../../UI/SeedInput'
 import history from '../../../services/history'
 import OnBoardingLayout from '../Layout/Layout'
 
@@ -39,41 +38,28 @@ class SecretPhraseQuiz extends Component {
 
   isInputPerfect = idx =>
     this.props.secretPhraseState.mnemonicPhrase[idx] === this.state.userInputWords[idx]
-  isInputInvalid = idx => !this.isInputValid(idx) && this.state.userInputWords[idx]
-  isInputValid = idx => this.state.userInputWords[idx]
+  isInputInvalid = idx => !!(!this.isInputValid(idx) && this.state.userInputWords[idx])
+  isInputValid = idx => !!(this.state.userInputWords[idx]
     && this.props.secretPhraseState.mnemonicPhrase[idx]
-      .indexOf(this.state.userInputWords[idx]) === 0
+      .indexOf(this.state.userInputWords[idx]) === 0)
   isInputIncomplete(idx) {
     const word = this.state.userInputWords[idx]
-    return word.length && !this.isInputPerfect(idx)
+    return !!(word.length && !this.isInputPerfect(idx))
   }
   renderQuizInputs() {
     return this.props.secretPhraseState.mnemonicPhrase.map((word, idx) => (
-      <li
-        key={idx}
-        className={cx({
-            perfect: this.isInputPerfect(idx),
-            invalid: this.isInputInvalid(idx),
-          })}
-      >
-        <input
-          type="text"
-          onChange={this.registerOnChangeFor(idx)}
-          className={cx({
-              perfect: this.isInputPerfect(idx),
-              invalid: this.isInputInvalid(idx),
-              valid: this.isInputValid(idx),
-              incomplete: this.isInputIncomplete(idx),
-             })}
-          value={this.state.userInputWords[idx]}
-          disabled={this.isInputPerfect(idx)}
-          ref={input => { this[`input${idx}`] = input }}
-        />
-        <IsValidIcon
-          isValid={this.isInputPerfect(idx)}
-          isHidden={!this.isInputPerfect(idx) && !this.isInputInvalid(idx)}
-        />
-      </li>
+      <SeedInput
+        key={`${idx}`}
+        idx={idx}
+        value={this.state.userInputWords[idx]}
+        isPerfect={this.isInputPerfect(idx)}
+        isInvalid={this.isInputInvalid(idx)}
+        isValid={this.isInputValid(idx)}
+        isIncomplete={this.isInputIncomplete(idx)}
+        isDisabled={this.isInputPerfect(idx)}
+        inputRef={input => { this[`input${idx}`] = input }}
+        onChange={this.registerOnChangeFor(idx)}
+      />
     ))
   }
 

--- a/app/components/OnBoarding/SecretPhraseQuiz/SecretPhraseQuiz.js
+++ b/app/components/OnBoarding/SecretPhraseQuiz/SecretPhraseQuiz.js
@@ -3,18 +3,36 @@ import { inject, observer } from 'mobx-react'
 import { Link } from 'react-router-dom'
 import Flexbox from 'flexbox-react'
 import _ from 'lodash'
+import { clipboard } from 'electron'
+import FontAwesomeIcon from '@fortawesome/react-fontawesome'
+import swal from 'sweetalert'
 
+import { getSeedFromClipboard } from '../../../utils/seedUtils'
+import PasteButton from '../../UI/PasteButton'
+import { isAnyInputActive } from '../../../utils/domUtils'
 import SeedInput from '../../UI/SeedInput'
 import history from '../../../services/history'
 import OnBoardingLayout from '../Layout/Layout'
+
+const getInitialInputsState = () => _.range(24).map(() => '')
 
 @inject('secretPhraseState')
 @observer
 class SecretPhraseQuiz extends Component {
   state = {
-    userInputWords: _.range(24).map(() => ''),
+    userInputWords: getInitialInputsState(),
   }
-
+  componentDidMount() {
+    window.addEventListener('keyup', this.onkeyup)
+  }
+  componentWillUnmount() {
+    window.removeEventListener('keyup', this.onkeyup)
+  }
+  onkeyup = evt => {
+    if (evt.key === 'v' && evt.ctrlKey && !isAnyInputActive()) {
+      this.paste(clipboard.readText())
+    }
+  }
   validateQuiz() {
     return this.props.secretPhraseState.mnemonicPhrase.every((word, idx) => this.isInputPerfect(idx))
   }
@@ -46,6 +64,21 @@ class SecretPhraseQuiz extends Component {
     const word = this.state.userInputWords[idx]
     return !!(word.length && !this.isInputPerfect(idx))
   }
+  reset = () => {
+    this.setState({ userInputWords: getInitialInputsState() })
+  }
+  paste = (clipboardContent) => {
+    const arraySeed = getSeedFromClipboard(clipboardContent)
+    if (!arraySeed) {
+      swal({
+        icon: 'warning',
+        title: 'bad format',
+        text: 'your clipboard content is not formatted as a valid seed',
+      })
+      return
+    }
+    this.setState({ userInputWords: arraySeed })
+  }
   renderQuizInputs() {
     return this.props.secretPhraseState.mnemonicPhrase.map((word, idx) => (
       <SeedInput
@@ -72,6 +105,12 @@ class SecretPhraseQuiz extends Component {
         <div className="devider after-title" />
 
         <ol className="passphrase-quiz">{this.renderQuizInputs()}</ol>
+        <div>
+          <PasteButton onClick={this.paste} />
+          <button onClick={this.reset} className="secondary button-on-right">
+            <FontAwesomeIcon icon={['far', 'trash']} />  Reset
+          </button>
+        </div>
         <div className="devider before-buttons" />
 
         <Flexbox flexDirection="row">

--- a/app/components/OnBoarding/SecretPhraseQuiz/SecretPhraseQuiz.scss
+++ b/app/components/OnBoarding/SecretPhraseQuiz/SecretPhraseQuiz.scss
@@ -1,3 +1,6 @@
+@import "styles/Variables";
+@import "styles/Animations";
+
 .secret-phrase-quiz-container, .import-wallet-container {
 
   ol.passphrase-quiz {
@@ -17,10 +20,14 @@
       }
 
       svg { position: absolute; top: 2px; right: -15px; }
-
-      &.invalid svg { color: $red; }
-      &.perfect svg { color: $blue; }
-
+      .toggle-input-visibility-icon {
+        display: none;
+        z-index: 100;
+        background: $dark-grey;
+      }
+      &.invalid .is-valid-icon { color: $red; }
+      &.perfect .is-valid-icon { color: $blue; }
+      
       input {
         width: 110px;
         margin: 0 12px;
@@ -33,6 +40,13 @@
         &.perfect { border: 1px solid $border-color; background: $dark-grey-2; }
       }
 
+      &:hover {
+        .toggle-input-visibility-icon {
+          display: block;
+          animation-name: fadeIn;
+          animation-duration: 0.4s
+        }
+      }
     }
 
   }

--- a/app/components/UI/CopyableTableCell.js
+++ b/app/components/UI/CopyableTableCell.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
-import ExternalLink from '../UI/ExternalLink'
 
+import ExternalLink from '../UI/ExternalLink'
 import { truncateString, isZenAsset } from '../../utils/helpers'
 
 const { clipboard } = require('electron')
@@ -22,22 +22,22 @@ class CopyableTableCell extends Component {
     }, 1250)
   }
 
-	renderString() {
-		const { string, istx } = this.props
-		let truncatedString = string
-		if (!isZenAsset(string)) {
+  renderString() {
+    const { string, istx } = this.props
+    let truncatedString = string
+    if (!isZenAsset(string)) {
       truncatedString = truncateString(string)
     }
 
-		if (istx) {
-			return (
-				<ExternalLink link={`https://zp.io/tx/${string}`}>
-					{truncatedString}
-				</ExternalLink>
-			)
-		}
-		return (truncatedString)
-	}
+    if (istx) {
+      return (
+        <ExternalLink link={`https://zp.io/tx/${string}`}>
+          {truncatedString}
+        </ExternalLink>
+      )
+    }
+    return (truncatedString)
+  }
 
   render() {
     const { string, istx } = this.props
@@ -51,8 +51,8 @@ class CopyableTableCell extends Component {
       <td className="align-left copyable" title={string}>
 
         <span title={string}>
-					{ this.renderString() }&nbsp;
-				</span>
+          { this.renderString() }&nbsp;
+        </span>
         <span
           onClick={() => { this.copyToClipboard(string) }}
           data-balloon={copyText}

--- a/app/components/UI/PasteButton.js
+++ b/app/components/UI/PasteButton.js
@@ -1,0 +1,36 @@
+// @flow
+
+import React, { Component } from 'react'
+import { clipboard } from 'electron'
+import cx from 'classnames'
+import FontAwesomeIcon from '@fortawesome/react-fontawesome'
+
+type Props = {
+  text?: string,
+  className?: string,
+  onClick: (any, any) => {}
+};
+class PasteButton extends Component<Props> {
+  static defaultProps = {
+    text: 'Paste',
+    className: '',
+  }
+  onClick = (evt: any) => {
+    this.props.onClick(clipboard.readText(), evt)
+  }
+  render() {
+    const {
+      onClick, className, text, ...remainingProps
+    } = this.props
+    return (
+      <button
+        className={cx('button secondary', className)}
+        onClick={this.onClick}
+        {...remainingProps}
+      ><FontAwesomeIcon icon={['far', 'copy']} className="" /> {text}
+      </button>
+    )
+  }
+}
+
+export default PasteButton

--- a/app/components/UI/SeedInput/SeedInput.js
+++ b/app/components/UI/SeedInput/SeedInput.js
@@ -12,7 +12,7 @@ type Props = {
   isInvalid: boolean,
   isValid: boolean,
   isIncomplete: boolean,
-  isDisabled: boolean,
+  isDisabled?: boolean,
   inputRef: () => {},
   onChange: () => {}
 };
@@ -22,6 +22,9 @@ type State = {
 };
 
 class SeedInput extends Component<Props, State> {
+  static defaultProps = {
+    isDisabled: false,
+  }
   state = {
     isVisible: false,
   }

--- a/app/components/UI/SeedInput/SeedInput.js
+++ b/app/components/UI/SeedInput/SeedInput.js
@@ -1,0 +1,68 @@
+// @flow
+
+import React, { Component } from 'react'
+import cx from 'classnames'
+
+import IsValidIcon from '../../Icons/IsValidIcon'
+import ToggleVisibilityIcon from '../../Icons/ToggleVisibilityIcon'
+
+type Props = {
+  value: string,
+  isPerfect: boolean,
+  isInvalid: boolean,
+  isValid: boolean,
+  isIncomplete: boolean,
+  isDisabled: boolean,
+  inputRef: () => {},
+  onChange: () => {}
+};
+
+type State = {
+  isVisible: boolean
+};
+
+class SeedInput extends Component<Props, State> {
+  state = {
+    isVisible: false,
+  }
+  toggleVisibility = () => {
+    this.setState(state => ({
+      isVisible: !state.isVisible,
+    }))
+  }
+  render() {
+    const {
+      value, isPerfect, isInvalid, isValid, isIncomplete, isDisabled, onChange, inputRef,
+    } = this.props
+    const { isVisible } = this.state
+    return (
+      <li
+        className={cx({
+            perfect: isPerfect,
+            invalid: isInvalid,
+          })}
+      >
+        <input
+          type={isVisible ? 'text' : 'password'}
+          onChange={onChange}
+          className={cx({
+              perfect: isPerfect,
+              invalid: isInvalid,
+              valid: isValid,
+              incomplete: isIncomplete,
+             })}
+          value={value}
+          disabled={isDisabled}
+          ref={inputRef}
+        />
+        <IsValidIcon
+          isValid={isPerfect}
+          isHidden={!isPerfect && !isInvalid}
+        />
+        <ToggleVisibilityIcon onClick={this.toggleVisibility} shouldShow={isVisible} />
+      </li>
+    )
+  }
+}
+
+export default SeedInput

--- a/app/components/UI/SeedInput/index.js
+++ b/app/components/UI/SeedInput/index.js
@@ -1,0 +1,1 @@
+export default from './SeedInput'

--- a/app/states/secret-phrase-state.js
+++ b/app/states/secret-phrase-state.js
@@ -32,7 +32,13 @@ class SecretPhraseState {
 
   @action.bound
   generateSeed() {
-    this.mnemonicPhrase = observable.array(bip39.generateMnemonic(256).split(' '))
+    this.mnemonicPhrase = bip39.generateMnemonic(256).split(' ')
+  }
+
+  @action
+  setMnemonicToImport(userInputWords) {
+    this.mnemonicPhrase = userInputWords
+    history.push('/set-password')
   }
 
   @action

--- a/app/styles/_Animations.scss
+++ b/app/styles/_Animations.scss
@@ -1,0 +1,4 @@
+@keyframes fadeIn {
+  from {opacity: 0}
+  to {opacity: 1}
+}

--- a/app/utils/__tests__/seedUtils.spec.js
+++ b/app/utils/__tests__/seedUtils.spec.js
@@ -1,0 +1,70 @@
+import validSeedExample from '../../../test/validSeedExample.json'
+import { parseSeedFromClipboard, getSeedFromClipboard } from '../seedUtils'
+
+test('[getSeedFromClipboard] empty string', () => {
+  const clipString = ''
+  const expected = false
+  expect(getSeedFromClipboard(clipString)).toBe(expected)
+})
+
+test('[getSeedFromClipboard] invalid seed', () => {
+  const clipString = 'one to three'
+  const expected = false
+  expect(getSeedFromClipboard(clipString)).toBe(expected)
+})
+
+test('[getSeedFromClipboard] valid seed', () => {
+  const clipString = String(validSeedExample)
+  const expected = validSeedExample
+  expect(getSeedFromClipboard(clipString)).toEqual(expected)
+})
+
+test('[parseSeedFromClipboard] empty string', () => {
+  const clipString = ''
+  const expected = false
+  expect(parseSeedFromClipboard(clipString)).toBe(expected)
+})
+
+test('[parseSeedFromClipboard] space separated', () => {
+  const clipString = 'one two three'
+  const expected = 'one two three'
+  expect(parseSeedFromClipboard(clipString)).toEqual(expected)
+})
+
+test('[parseSeedFromClipboard] comma and space separated', () => {
+  const clipString = 'one, two, three'
+  const expected = 'one two three'
+  expect(parseSeedFromClipboard(clipString)).toEqual(expected)
+})
+
+test('[parseSeedFromClipboard] comma separated', () => {
+  const clipString = 'one,two,three'
+  const expected = 'one two three'
+  expect(parseSeedFromClipboard(clipString)).toEqual(expected)
+})
+
+test('[parseSeedFromClipboard] comma and mixed spaces separated', () => {
+  const clipString = 'one,two, three'
+  const expected = 'one two three'
+  expect(parseSeedFromClipboard(clipString)).toEqual(expected)
+})
+
+test('[parseSeedFromClipboard] linebreak separated', () => {
+  const clipString = `one
+two
+three`
+  const expected = 'one two three'
+  expect(parseSeedFromClipboard(clipString)).toEqual(expected)
+})
+
+test('[parseSeedFromClipboard] array format', () => {
+  const clipString = '["one", "two", "three"]'
+  const expected = 'one two three'
+  expect(parseSeedFromClipboard(clipString)).toEqual(expected)
+})
+
+test('[parseSeedFromClipboard] one valid word', () => {
+  const clipString = 'abandon'
+  const expected = false
+  expect(parseSeedFromClipboard(clipString)).toEqual(expected)
+})

--- a/app/utils/domUtils.js
+++ b/app/utils/domUtils.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const isAnyInputActive = () => document.activeElement.tagName === 'INPUT'

--- a/app/utils/helpers.js
+++ b/app/utils/helpers.js
@@ -5,8 +5,6 @@ import bech32 from 'bech32'
 import db from '../services/store'
 import { ZEN_ASSET_NAME, ZEN_ASSET_HASH, ZEN_TO_KALAPA_RATIO } from '../constants'
 
-import bip39Words from './bip39Words'
-
 const validPrefixes = ['zen', 'tzn', 'czen', 'ctzn']
 const savedContracts = db.get('savedContracts').value()
 
@@ -20,31 +18,6 @@ export const getAssetName = (asset: ?string) => {
   }
   return ''
 }
-
-// TODO [AdGo] 06/05/19 - rewrite this
-/* eslint-disable no-restricted-syntax */
-export const isValidBip39Word = (string: ?string) => {
-  if (string) {
-    for (const word of bip39Words) {
-      if (word.includes(string)) {
-        return true
-      }
-    }
-    return false
-  }
-}
-
-export const isBip39Word = (string: ?string) => {
-  if (string) {
-    for (const word of bip39Words) {
-      if (word === string) {
-        return true
-      }
-    }
-  }
-  return false
-}
-/* eslint-enable no-restricted-syntax */
 
 export const truncateString = (string: ?string) => {
   if (string) {

--- a/app/utils/helpers.js
+++ b/app/utils/helpers.js
@@ -41,8 +41,8 @@ export const isBip39Word = (string: ?string) => {
         return true
       }
     }
-    return false
   }
+  return false
 }
 /* eslint-enable no-restricted-syntax */
 

--- a/app/utils/seedUtils.js
+++ b/app/utils/seedUtils.js
@@ -2,27 +2,11 @@ import bip39 from 'bip39'
 
 import bip39Words from './bip39Words'
 
-export const isValidBip39Word = (string: ?string) => {
-  if (string) {
-    for (const word of bip39Words) {
-      if (word.includes(string)) {
-        return true
-      }
-    }
-  }
-  return false
-}
+export const isValidBip39Word = (string: ?string) =>
+  !!(string && bip39Words.find(word => word.includes(string)))
 
-export const isBip39Word = (string: ?string) => {
-  if (string) {
-    for (const word of bip39Words) {
-      if (word === string) {
-        return true
-      }
-    }
-  }
-  return false
-}
+export const isBip39Word = (string: ?string) =>
+  !!(string && bip39Words.find(word => word === string))
 
 export const parseSeedFromClipboard = (clipboardContents) => {
   if (!clipboardContents) {

--- a/app/utils/seedUtils.js
+++ b/app/utils/seedUtils.js
@@ -1,0 +1,57 @@
+import bip39 from 'bip39'
+
+import bip39Words from './bip39Words'
+
+export const isValidBip39Word = (string: ?string) => {
+  if (string) {
+    for (const word of bip39Words) {
+      if (word.includes(string)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+export const isBip39Word = (string: ?string) => {
+  if (string) {
+    for (const word of bip39Words) {
+      if (word === string) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+export const parseSeedFromClipboard = (clipboardContents) => {
+  if (!clipboardContents) {
+    return false
+  }
+  try {
+    const parsed = JSON.parse(clipboardContents)
+    if (Array.isArray(parsed)) {
+      return parsed.join(' ')
+    }
+  } catch (err) {
+    //
+  }
+  if (clipboardContents.match(',')) {
+    return clipboardContents.replace(/(, |,)/g, ' ')
+  }
+  if (clipboardContents.match('\n')) {
+    return clipboardContents.replace(/\n/g, ' ')
+  }
+  if (clipboardContents.match(' ')) {
+    return clipboardContents
+  }
+  return false
+}
+
+export const getSeedFromClipboard = (clipboardContents) => {
+  const parsed = parseSeedFromClipboard(clipboardContents.trim())
+  if (!parsed || !bip39.validateMnemonic(parsed)) {
+    return false
+  }
+  return parsed.split(' ')
+}


### PR DESCRIPTION
`ImportWallet`  and `SecretPhraseQuiz`
- add reset and paste buttons
- support paste with `ctrl + v`
- hide input fields+ toggle visibility option
- refactor to use `SeedInput`
---
`ImportWallet`
- improve error message
- refactor, use similar logic to `SecretPhraseQuiz`
- only update `secretPhraseState` store on completion
---
`SecretPhrase`
- add copy to clipboard button
---
MISC
- add classnames to `IsValidIcon` and `ToggleVisibilityIcon` buttons
- refactor big39 help functions and move to own file
- lint `CopyableTableCell.js`