### PR TITLE
fix localisation number bug + refactor amount handling

### DIFF
--- a/app/components/Balances/Balances.js
+++ b/app/components/Balances/Balances.js
@@ -7,8 +7,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 import Layout from '../UI/Layout/Layout'
 import CopyableTableCell from '../UI/CopyableTableCell'
 
-@inject('balances')
-@inject('transaction')
+@inject('balances', 'transaction')
 @observer
 class Balances extends Component {
   componentDidMount() {
@@ -17,26 +16,23 @@ class Balances extends Component {
 
   render() {
     const { balances } = this.props
-    const balancesRows = balances.assets.map(asset => {
-      const assetName = balances.getAssetName(asset.asset)
-      return (
-        <React.Fragment key={asset.asset}>
-          <tr>
-            <td className="align-left text" title={assetName}>{assetName}</td>
-            <CopyableTableCell string={asset.asset} />
-            <td className="bright-blue" title={asset.balance} >
-              {asset.balance}
-            </td>
-            <td className="align-right" >
-              <Link className="button small with-icon" to="/send-tx" title="Send Transaction" onClick={() => this.props.transaction.updateAsset(asset)}>
-                <FontAwesomeIcon icon={['far', 'paper-plane']} /> <span className="button-text">Send</span>
-              </Link>
-            </td>
-          </tr>
-          <tr className="separator" />
-        </React.Fragment>
-      )
-    })
+    const balancesRows = balances.assets.map(asset => (
+      <React.Fragment key={asset.asset}>
+        <tr>
+          <td className="align-left text" title={asset.name}>{asset.name}</td>
+          <CopyableTableCell string={asset.asset} />
+          <td className="bright-blue" title={asset.balance}>
+            {asset.balanceDisplay}
+          </td>
+          <td className="align-right" >
+            <Link className="button small with-icon" to="/send-tx" title="Send Transaction" onClick={() => this.props.transaction.updateAsset(asset)}>
+              <FontAwesomeIcon icon={['far', 'paper-plane']} /> <span className="button-text">Send</span>
+            </Link>
+          </td>
+        </tr>
+        <tr className="separator" />
+      </React.Fragment>
+    ))
 
     return (
       <Layout className="balances">

--- a/app/components/TxHistory/SingleTxDelta.js
+++ b/app/components/TxHistory/SingleTxDelta.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
-import { normalizeTokens, isZenAsset, getAssetName } from '../../utils/helpers'
+import { getAssetName } from '../../utils/helpers'
+import { normalizeTokens, isZenAsset } from '../../utils/zenUtils'
 import CopyableTableCell from '../UI/CopyableTableCell'
 
 class SingleTxDelta extends Component {

--- a/app/components/UI/AutoSuggestAssets/AutoSuggestAssets.js
+++ b/app/components/UI/AutoSuggestAssets/AutoSuggestAssets.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { inject, observer, PropTypes as PropTypesMobx } from 'mobx-react'
+import { inject, observer } from 'mobx-react'
 import Flexbox from 'flexbox-react'
 import Autosuggest from 'react-autosuggest'
 import cx from 'classnames'
@@ -16,10 +16,10 @@ class AutoSuggestAssets extends Component {
   static propTypes = {
     asset: PropTypes.string.isRequired,
     balances: PropTypes.shape({
-      assets: PropTypesMobx.observableArrayOf(PropTypes.shape({
+      assets: PropTypes.arrayOf(PropTypes.shape({
         asset: PropTypes.string.isRequired,
       }).isRequired).isRequired,
-      filteredBalancesWithNames: PropTypes.func.isRequired,
+      filteredBalances: PropTypes.func.isRequired,
       getAssetName: PropTypes.func.isRequired,
     }).isRequired,
     onUpdateParent: PropTypes.func.isRequired,
@@ -61,12 +61,13 @@ class AutoSuggestAssets extends Component {
     const { asset } = this.getChosenAsset()
     this.props.onUpdateParent({ asset })
   }
+  // TODO refactor to getter
   getChosenAsset() {
     return this.props.balances.assets.find(a => a.asset === this.state.suggestionInputValue)
   }
 
   getSuggestions = query => {
-    const filtered = this.props.balances.filteredBalancesWithNames(query)
+    const filtered = this.props.balances.filteredBalances(query)
     if (filtered.length === 1 && filtered[0].asset === query) {
       return []
     }
@@ -104,6 +105,7 @@ class AutoSuggestAssets extends Component {
   }
 
   renderChosenAssetName() {
+    // TODO get name directly from chosen asset, no need to go through balances
     const chosenAssetName = this.props.balances.getAssetName(this.state.suggestionInputValue)
     if (chosenAssetName) {
       return (

--- a/app/components/UI/CopyableTableCell.js
+++ b/app/components/UI/CopyableTableCell.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 
 import ExternalLink from '../UI/ExternalLink'
-import { truncateString, isZenAsset } from '../../utils/helpers'
+import { truncateString } from '../../utils/helpers'
+import { isZenAsset } from '../../utils/zenUtils'
 
 const { clipboard } = require('electron')
 

--- a/app/components/UI/Topbar/Topbar.js
+++ b/app/components/UI/Topbar/Topbar.js
@@ -5,8 +5,7 @@ import classnames from 'classnames'
 import Flexbox from 'flexbox-react'
 import FontAwesomeIcon from '@fortawesome/react-fontawesome'
 
-@inject('balances')
-@inject('history')
+@inject('balances', 'history')
 @observer
 class Header extends Component {
   static propTypes = {
@@ -47,7 +46,7 @@ class Header extends Component {
   }
 
   render() {
-    const { zen } = this.props.balances
+    const { balances } = this.props
     const className = classnames('header', this.props.className)
     return (
       <Flexbox className={className} element="header" >
@@ -57,7 +56,7 @@ class Header extends Component {
             <span className="total-balance">Total Balance</span>
             <span className="zen-symbol">ZP</span>
           </div>
-          <div className="account-balance">{zen}</div>
+          <div className="account-balance">{balances.zenDisplay}</div>
         </div>
       </Flexbox>
     )

--- a/app/components/UnlockWallet/UnlockWallet.js
+++ b/app/components/UnlockWallet/UnlockWallet.js
@@ -104,7 +104,7 @@ class UnlockWallet extends Component<Props, State> {
           <a style={{ textDecoration: 'underline' }} onClick={forgotPasswordModal} className="forgot-password">
             Forgot your password? Import your wallet again or create a new one
           </a>
-
+          {/* $FlowFixMe */ }
           <NonMainNetBottomBar />
         </Flexbox>
       </Flexbox>

--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -1,3 +1,4 @@
+export const ZENP_MIN_DECIMALS = 2
 export const ZENP_MAX_DECIMALS = 8
 export const ZEN_ASSET_HASH = '00'
 export const ZEN_ASSET_NAME = 'ZP'

--- a/app/services/api-service.js
+++ b/app/services/api-service.js
@@ -2,7 +2,6 @@
 import axios from 'axios'
 import type { observableArray } from 'mobx-react'
 
-import { isZenAsset } from '../utils/helpers'
 import { getServerAddress, getCrowdsaleServerAddress } from '../config/server-address'
 
 const crowdsaleServerAddress = getCrowdsaleServerAddress()
@@ -12,15 +11,16 @@ type addressType = string;
 
 type Asset = {
   asset: string,
-  balance: string
+  balance: number
 };
 
 export async function getBalances(): Promise<Asset[]> {
   const response = await axios.get(`${getServerAddress()}/wallet/balance`)
-  return response.data.map(asset => ({
-    ...asset,
-    balance: normalizePresentableAmount(asset.asset, asset.balance),
-  }))
+  return response.data
+  // return response.data.map(asset => ({
+  //   ...asset,
+  //   balance: normalizePresentableAmount(asset.asset, asset.balance),
+  // }))
 }
 
 export async function getPublicAddress(): Promise<string> {
@@ -42,7 +42,7 @@ export async function postTransaction(tx: Transaction & Password): Promise<strin
     outputs: [{
       asset,
       address: to,
-      amount: normalizeSendableAmount(asset, amount),
+      amount,
     }],
     password,
   }
@@ -101,7 +101,7 @@ export async function postRunContractMessage(contractMessage: ContractMessage & 
     finaldata.spends = [
       {
         asset,
-        amount: normalizeSendableAmount(asset, amount),
+        amount,
       },
     ]
   }
@@ -215,19 +215,6 @@ export async function postWalletMnemonicphrase(password: string): string {
   })
   // $FlowFixMe
   return response.data
-}
-
-export function normalizeSendableAmount(asset: hash, amount: number) {
-  return isZenAsset(asset) ? Math.floor(amount * 100000000) : amount
-}
-export function normalizePresentableAmount(asset: hash, amount: number) {
-  if (isZenAsset(asset)) {
-    return (amount / 100000000).toLocaleString(undefined, {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 8,
-    })
-  }
-  return amount.toLocaleString()
 }
 // CROWDSALE APIS //
 

--- a/app/states/__tests__/balances-state.spec.js
+++ b/app/states/__tests__/balances-state.spec.js
@@ -30,52 +30,39 @@ describe('BalancesState', () => {
     cut.assets = [asset1]
     expect(cut.getBalanceFor('bar')).toEqual(1)
   })
-  it('[assetsWithNames] should get asset with names', () => {
-    cut.assets = [
-      { asset: ZEN_ASSET_HASH, balance: 2 },
-      { asset: awesomeTokenAsset, balance: 3 },
-    ]
-    expect(cut.assetsWithNames).toEqual([
-      { asset: ZEN_ASSET_HASH, balance: 2, name: ZEN_ASSET_NAME },
-      { asset: awesomeTokenAsset, balance: 3, name: 'Awesome Token' },
-    ])
+  it('[filteredBalances] should return empty array when no assets are present', () => {
+    expect(cut.filteredBalances()).toEqual([])
   })
-  it('[assetsWithNames] should return empty array', () => {
-    expect(cut.assetsWithNames).toEqual([])
-  })
-  it('[filteredBalancesWithNames] should return empty array when no assets are present', () => {
-    expect(cut.filteredBalancesWithNames()).toEqual([])
-  })
-  it('[filteredBalancesWithNames] should return cut.assetsWithNames when query is empty', () => {
+  it('[filteredBalances] should return cut.assetsWithNames when query is empty', () => {
     const mockedAssetsWithNames = [{ asset: ZEN_ASSET_HASH, balance: 2, name: 'ZENP' }]
     Object.defineProperty(cut, 'assetsWithNames', {
       get: jest.fn(() => mockedAssetsWithNames),
     })
-    expect(cut.filteredBalancesWithNames()).toEqual(mockedAssetsWithNames)
+    expect(cut.filteredBalances()).toEqual(mockedAssetsWithNames)
   })
-  it('[filteredBalancesWithNames] should return [] when no balances matches', () => {
+  it('[filteredBalances] should return [] when no balances matches', () => {
     const mockedAssetsWithNames = [{ asset: ZEN_ASSET_HASH, balance: 2, name: 'ZENP' }]
     Object.defineProperty(cut, 'assetsWithNames', {
       get: jest.fn(() => mockedAssetsWithNames),
     })
-    expect(cut.filteredBalancesWithNames('123')).toEqual([])
+    expect(cut.filteredBalances('123')).toEqual([])
   })
-  it('[filteredBalancesWithNames] should return matching object by name', () => {
+  it('[filteredBalances] should return matching object by name', () => {
     const assetWithName1 = { name: 'foo', asset: 'bar', balance: 2 }
     const assetWithName2 = { name: 'asset2', asset: 'asset2', balance: 2 }
     const mockedAssetsWithNames = [assetWithName1, assetWithName2]
     Object.defineProperty(cut, 'assetsWithNames', {
       get: jest.fn(() => mockedAssetsWithNames),
     })
-    expect(cut.filteredBalancesWithNames('foo')).toEqual([assetWithName1])
+    expect(cut.filteredBalances('foo')).toEqual([assetWithName1])
   })
-  it('[filteredBalancesWithNames] should return matching object by contractId', () => {
+  it('[filteredBalances] should return matching object by contractId', () => {
     const assetWithName1 = { name: 'foo', asset: 'bar', balance: 1 }
     const assetWithName2 = { name: 'assetWithName2', asset: 'assetWithName2', balance: 2 }
     const mockedAssetsWithNames = [assetWithName1, assetWithName2]
     Object.defineProperty(cut, 'assetsWithNames', {
       get: jest.fn(() => mockedAssetsWithNames),
     })
-    expect(cut.filteredBalancesWithNames('bar')).toEqual([assetWithName1])
+    expect(cut.filteredBalances('bar')).toEqual([assetWithName1])
   })
 })

--- a/app/states/contract-message.js
+++ b/app/states/contract-message.js
@@ -3,12 +3,13 @@ import _ from 'lodash'
 
 import { postRunContractMessage } from '../services/api-service'
 import { getNamefromCodeComment } from '../utils/helpers'
+import { zenToKalapas, isZenAsset } from '../utils/zenUtils'
 import db from '../services/store'
 
 class ContractMessageState {
   @observable address = ''
   @observable contractName = ''
-  @observable amount = ''
+  @observable amountDisplay = ''
   @observable command = ''
   @observable data
   @observable status = ''
@@ -26,7 +27,7 @@ class ContractMessageState {
       const data = {
         asset: this.asset,
         address: this.address,
-        amount: Number(this.amount),
+        amount: isZenAsset(this.asset) ? zenToKalapas(this.amount) : this.amount,
         command: this.command,
         data: this.data,
         password,
@@ -73,7 +74,12 @@ class ContractMessageState {
   @action
   updateAddress(address) {
     this.address = address
-    this.amount = ''
+    this.amountDisplay = ''
+  }
+
+  @action
+  updateAmountDisplay(amountDisplay) {
+    this.amountDisplay = amountDisplay
   }
 
   @action
@@ -81,11 +87,15 @@ class ContractMessageState {
     this.inprogress = false
     this.asset = ''
     this.address = ''
-    this.amount = ''
+    this.amountDisplay = ''
     this.command = ''
     this.data = ''
     this.errorMessage = ''
     this.status = ''
+  }
+
+  get amount() {
+    return Number(this.amountDisplay)
   }
 }
 

--- a/app/states/contract-state.js
+++ b/app/states/contract-state.js
@@ -1,5 +1,5 @@
 // @flow
-import { observable, action, runInAction } from 'mobx'
+import { observable, action, runInAction, computed } from 'mobx'
 import { some } from 'lodash'
 
 import { postActivateContract } from '../services/api-service'
@@ -14,7 +14,7 @@ class ContractState {
   @observable contractId: string
   @observable address: string
   @observable code = ''
-  @observable numberOfBlocks = ''
+  @observable blocksAmountDisplay = ''
   @observable activationCost = ''
   @observable blockAmountHasError = false
   @observable status: 'inprogress' | 'success' | 'error' | ''
@@ -40,7 +40,7 @@ class ContractState {
     this.status = 'inprogress'
     const data = {
       code: this.code,
-      numberOfBlocks: Number(this.numberOfBlocks),
+      numberOfBlocks: this.blocksAmount,
       password,
     }
     try {
@@ -87,7 +87,7 @@ class ContractState {
   }
 
   get formIsDirty(): boolean {
-    return !(this.name || this.code || this.numberOfBlocks)
+    return !(this.name || this.code || this.blocksAmountDisplay)
   }
 
   @action.bound
@@ -97,7 +97,7 @@ class ContractState {
     this.code = ''
     this.contractId = ''
     this.address = ''
-    this.numberOfBlocks = ''
+    this.blocksAmountDisplay = ''
     this.activationCost = ''
     this.status = ''
     this.inprogress = false
@@ -105,6 +105,15 @@ class ContractState {
     this.errorMessage = ''
     this.acceptedFiles = []
     this.rejectedFiles = []
+  }
+
+  @computed
+  get blocksAmount() {
+    return Number(this.blocksAmountDisplay)
+  }
+
+  updateBlocksAmountDisplay(blocksAmountDisplay: string) {
+    this.blocksAmountDisplay = blocksAmountDisplay
   }
 }
 

--- a/app/states/transaction-state.js
+++ b/app/states/transaction-state.js
@@ -1,20 +1,26 @@
 import { observable, action, runInAction } from 'mobx'
 
 import { postTransaction } from '../services/api-service'
+import { zenToKalapas, isZenAsset } from '../utils/zenUtils'
 
 class TransactionState {
   @observable asset = ''
   @observable to = ''
-  @observable amount = ''
+  @observable amountDisplay = ''
   @observable status = ''
   @observable inprogress = false
   @observable errorMessage = ''
 
   @action
-  async createTransaction(tx, password) {
+  async createTransaction(password) {
     try {
       this.inprogress = true
-      const data = { ...tx, amount: Number(tx.amount), password }
+      const data = {
+        amount: isZenAsset(this.asset) ? zenToKalapas(this.amount) : this.amount,
+        asset: this.asset,
+        to: this.to,
+        password,
+      }
       const response = await postTransaction(data)
 
       runInAction(() => {
@@ -44,14 +50,29 @@ class TransactionState {
   }
 
   @action
+  updateAssetFromSuggestions(asset) {
+    this.asset = asset
+    this.amountDisplay = ''
+  }
+
+  @action
+  updateAmountDisplay(amountDisplay) {
+    this.amountDisplay = amountDisplay
+  }
+
+  @action
   resetForm() {
     this.inprogress = false
     this.asset = ''
     this.assetName = ''
     this.to = ''
-    this.amount = ''
+    this.amountDisplay = ''
     this.status = ''
     this.errorMessage = ''
+  }
+
+  get amount() {
+    return Number(this.amountDisplay)
   }
 }
 

--- a/app/utils/helpers.js
+++ b/app/utils/helpers.js
@@ -3,13 +3,14 @@
 import bech32 from 'bech32'
 
 import db from '../services/store'
-import { ZEN_ASSET_NAME, ZEN_ASSET_HASH, ZEN_TO_KALAPA_RATIO } from '../constants'
+import { ZEN_ASSET_NAME, ZEN_ASSET_HASH } from '../constants'
 
 const validPrefixes = ['zen', 'tzn', 'czen', 'ctzn']
 const savedContracts = db.get('savedContracts').value()
 
 export const isDev = () => process.env.NODE_ENV === 'development'
 
+// TODO use exposed asset names from stores instead
 export const getAssetName = (asset: ?string) => {
   if (asset === ZEN_ASSET_HASH) { return ZEN_ASSET_NAME }
   const contractFromDb = savedContracts.find(contract => contract.contractId === asset)
@@ -25,18 +26,6 @@ export const truncateString = (string: ?string) => {
       ? `${string.substr(0, 6)}...${string.substr(string.length - 6)}`
       : string
   }
-}
-
-export const normalizeTokens = (number: number, isZen: ?boolean) => {
-  const newNumber = number / ZEN_TO_KALAPA_RATIO
-  if (isZen) {
-    const formattedNumber = newNumber.toLocaleString(undefined, {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 8,
-    })
-    return formattedNumber
-  }
-  return number.toLocaleString()
 }
 
 export const stringToNumber = (str: ?string) => str && parseFloat(str.replace(/,/g, ''))
@@ -55,10 +44,6 @@ export const isValidAddress = (address: ?string, type?: 'contract' | 'pubKey' = 
     return false
   }
 }
-
-export const isZenAsset = (asset: string) => asset === ZEN_ASSET_HASH
-
-export const zenToKalapa = (zen: number) => zen * ZEN_TO_KALAPA_RATIO
 
 export const getNamefromCodeComment = (code: string) => {
   const startRegex = /NAME_START:/
@@ -110,4 +95,23 @@ export const validateInputNumber = (str: string, maxDecimal: number = 0) => {
     return str.split('.')[0] + '.' + str.split('.')[1].substr(0, maxDecimal) // eslint-disable-line prefer-template
   }
   return str
+}
+
+export const minimumDecimalPoints = (num: string | number, decimalPoints: number): string => {
+  num = String(num)
+  // Split the input string into two arrays containing integers/decimals
+  const res = num.split('.')
+  // If there is no decimal point or only one decimal place found.
+  if (res.length === 1 || res[1].length < decimalPoints) {
+  // Set the number to two decimal places
+    return Number(num).toFixed(decimalPoints)
+  }
+  // Return updated or original number.
+  return num
+}
+
+export const numberWithCommas = (x: number | string): string => {
+  const parts = x.toString().split('.')
+  parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+  return parts.join('.')
 }

--- a/app/utils/zenUtils.js
+++ b/app/utils/zenUtils.js
@@ -1,0 +1,29 @@
+import { ZEN_ASSET_HASH, ZEN_TO_KALAPA_RATIO, ZENP_MAX_DECIMALS } from '../constants'
+import { minimumDecimalPoints, numberWithCommas } from '../utils/helpers'
+
+export const isZenAsset = (asset: string) => asset === ZEN_ASSET_HASH
+export const zenToKalapas = zen => zen * ZEN_TO_KALAPA_RATIO
+export const kalapasToZen = kalapas => kalapas / ZEN_TO_KALAPA_RATIO
+/* eslint-disable function-paren-newline */
+export const zenBalanceDisplay = kalapas =>
+  minimumDecimalPoints(
+    numberWithCommas(
+      Number(
+        kalapasToZen(kalapas).toFixed(ZENP_MAX_DECIMALS),
+      ),
+    ),
+    2,
+  )
+/* eslint-enable function-paren-newline */
+
+export const normalizeTokens = (number: number, isZen: ?boolean) => {
+  const newNumber = number / ZEN_TO_KALAPA_RATIO
+  if (isZen) {
+    const formattedNumber = newNumber.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 8,
+    })
+    return formattedNumber
+  }
+  return number.toLocaleString()
+}


### PR DESCRIPTION
fixes #72 

- cleanup a castings between numbers and strings, by doing always computations on numbers, and deriving one type from the other.
- separate numbers and their displays for assets, contracts, txs
- remove normalization from `api-service.js`, handle in stores
- move zen related helpers to `zenUtils.js`
- unify multiple injects in components
- expose names, balance, and balanceDisplay in balance store
- move some store mutations to actions

QA
===
- [ ] zen balance displayed correctly in top bar
- [ ] non zen balance displayed correctly in top bar
- [ ] zen balance displayed correctly in portfolio
- [ ] non zen balance displayed correctly in top bar
- [ ] zen balance displayed correctly in top bar
- [ ] send zen
- [ ] send non zen
- [ ] deploy contract
- [ ] run contract with zen tokens
- [ ] run contract with non zen tokens