### PR TITLE
fix prereq mono check for mac

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -17,7 +17,7 @@ import { app, BrowserWindow, dialog } from 'electron'
 import ZenNode from './ZenNode'
 import db from './services/store'
 import MainProcessErrorReporter from './utils/errorReporting/MainProcessErrorReporter'
-// import prereqCheck from './utils/prereqCheck'
+import prereqCheck from './utils/prereqCheck'
 
 const isUiOnly = (process.env.UIONLY || process.argv.indexOf('--uionly') > -1 || process.argv.indexOf('uionly') > -1)
 
@@ -63,7 +63,7 @@ app.on('ready', async () => {
     await installExtensions()
   }
 
-  // prereqCheck()
+  prereqCheck()
 
   console.log('process.argv', process.argv)
 

--- a/app/utils/prereqCheck.js
+++ b/app/utils/prereqCheck.js
@@ -77,7 +77,7 @@ function validateMono() {
 
 function getMonoStatus() {
   try {
-    const monoOutput = execSync('mono --version', { encoding: 'utf-8' })
+    const monoOutput = execSync(`${monoPath()} --version`, { encoding: 'utf-8' })
     try {
       const [major, minor] = monoOutput.split('version ')[1].split(' ')[0].split('.')
       if (major <= 4 || (major === 5 && minor < 10)) {
@@ -91,4 +91,8 @@ function getMonoStatus() {
     console.error('error executing mono --version from terminal\n', monoOutputErr)
     return { status: ERR_STATUS, msg: `please install mono\n${monoOutputErr}` }
   }
+}
+
+function monoPath() {
+  return !isOsx() ? 'mono' : '/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono'
 }


### PR DESCRIPTION
Used same mono path logic from [zen node](https://gitlab.com/zenprotocol/zenprotocol/blob/e13e135c838c2fc8c19ec70b23ab2e588a4fba3c/package/index.js#L22) package.

QA
===
- [ ] windows without mono
- [ ] linux without mono
- [ ] mac without mono
- [ ] windows with mono
- [ ] linux with mono
- [ ] mac with mono (brew installation)
- [ ] mac with mono (non brew installation)
