### PR TITLE
Adding zip target to mac build in order to generate latest-mac.yml file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zen/zen-wallet",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -184,9 +184,9 @@
       }
     },
     "@zen/zen-node": {
-      "version": "0.9.16",
-      "resolved": "https://www.myget.org/F/zenprotocol/npm/@zen/zen-node/-/@zen/zen-node-0.9.16.tgz",
-      "integrity": "sha1-jDIx7BIstHjxEnbc/wZyXOOw2aE="
+      "version": "0.9.17",
+      "resolved": "https://www.myget.org/F/zenprotocol/npm/@zen/zen-node/-/@zen/zen-node-0.9.17.tgz",
+      "integrity": "sha1-JxZ53KJ5GMVKa1HwM7a7s0Z2+T8="
     },
     "@zen/zenjs": {
       "version": "0.0.11",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     },
     "mac": {
       "target": [
-        "dmg"
+        "dmg",
+        "zip"
       ]
     },
     "win": {


### PR DESCRIPTION
This adds a zip target for the wallet build output. This is required for electron autoupdate to work (see Note 2 [here](https://www.electron.build/auto-update)).

### Context
There has been some intent to leverage the auto-update feature of electron for the desktop wallet to make the update process more user friendly e.g., [here](https://trello.com/c/R6y26I12/396-auto-update-round-2). The electron auto update plugin requires certain artefacts (`latest.yml, latest-mac.yml`) to be generated along side the installers found on the github release pages. These are currently not generated. Explicitly adding a `zip` target to the mac build configuration should cause the files to be generated.

Please let me know when merged and a new build is run.